### PR TITLE
Hendelser og varsler

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 ```
 
 ### TestContainers
-Testene starter opp noen docker-containerer via TestContainers, dette kan ta forholdsvis lang tid og er plagsomt hvis man må gjøre dette hele tiden. Man kan konfigurere TestContainers til å ikke stoppe containerner etter testene er kjørt, noe som gjør at oppstartstiden for testene reduseres med ca 90% etter de har først startet. 
+Testene starter opp noen docker-containerer via TestContainers, dette kan ta forholdsvis lang tid og er plagsomt hvis man må gjøre dette hele tiden. Man kan konfigurere TestContainers til å ikke stoppe containere etter testene er kjørt, noe som gjør at oppstartstiden for testene reduseres med ca 90% etter første kjøring. 
 
-For å skru dette på må det opprettes en `.testcontainsers.properties` configfil i `$HOME`:
+For å skru dette på må det opprettes en `.testcontainsers.properties` configfil i `$HOME` som inneholder `testcontainers.reuse.enable=true`:
 ```shell 
 echo "testcontainers.reuse.enable=true" >> ~/.testcontainers.properties
 ```
@@ -21,7 +21,7 @@ echo "testcontainers.reuse.enable=true" >> ~/.testcontainers.properties
 En miljøvariabel `TESTCONTAINERS_REUSE=true` må også settes settes.
 
 #### Obs
-Det er viktig å være obs på at da blir disse containerene kjørende på maskinen til de blir stoppet manuelt med `docker stop {id}` eller `docker stop $(docker -ps -q)` for å stoppe alle kjørende containerer. h
+Det er viktig å være obs på at disse containerene kjørende blir kjørende på maskinen til de blir stoppet manuelt med `docker stop {id}` eller `docker stop $(docker -ps -q)` for å stoppe alle kjørende containerer.
 
 Hvis man bruker TestContainers i andre prosjekter også, så kan det være en risiko for at de vil gjenbruke de samme containerne som allerede er startet av et annet prosjekt. Ved å sette et unikt label for hver container skal det teoretisk sett ikke skje: `container.withLabel("reuse.UUID", "dc04f4eb-01b6-4e32-b878-f0663d583a52")`.
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,20 @@
 ```
 ./gradlew build
 ```
+
+### TestContainers
+Testene starter opp noen docker-containerer via TestContainers, dette kan ta forholdsvis lang tid og er plagsomt hvis man må gjøre dette hele tiden. Man kan konfigurere TestContainers til å ikke stoppe containerner etter testene er kjørt, noe som gjør at oppstartstiden for testene reduseres med ca 90% etter de har først startet. 
+
+For å skru dette på må det opprettes en `.testcontainsers.properties` configfil i `$HOME`:
+```shell 
+echo "testcontainers.reuse.enable=true" >> ~/.testcontainers.properties
+```
+
+En miljøvariabel `TESTCONTAINERS_REUSE=true` må også settes settes.
+
+#### Obs
+Det er viktig å være obs på at da blir disse containerene kjørende på maskinen til de blir stoppet manuelt med `docker stop {id}` eller `docker stop $(docker -ps -q)` for å stoppe alle kjørende containerer. h
+
+Hvis man bruker TestContainers i andre prosjekter også, så kan det være en risiko for at de vil gjenbruke de samme containerne som allerede er startet av et annet prosjekt. Ved å sette et unikt label for hver container skal det teoretisk sett ikke skje: `container.withLabel("reuse.UUID", "dc04f4eb-01b6-4e32-b878-f0663d583a52")`.
+
+Reuse kan naturligvis ikke benyttes i CI/CD.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,8 @@ dependencies {
 
     implementation("com.github.ben-manes.caffeine:caffeine:$caffeineVersion")
 
+    implementation("no.nav.tms.varsel:kotlin-builder:1.0.0")
+
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashEncoderVersion")
     implementation("no.nav.common:log:$commonVersion")

--- a/src/main/kotlin/no/nav/amt/distribusjon/Application.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/Application.kt
@@ -14,6 +14,10 @@ import no.nav.amt.distribusjon.application.plugins.configureMonitoring
 import no.nav.amt.distribusjon.application.plugins.configureRouting
 import no.nav.amt.distribusjon.application.plugins.configureSerialization
 import no.nav.amt.distribusjon.db.Database
+import no.nav.amt.distribusjon.hendelse.HendelseConsumer
+import no.nav.amt.distribusjon.varsel.VarselProducer
+import no.nav.amt.distribusjon.varsel.VarselRepository
+import no.nav.amt.distribusjon.varsel.VarselService
 
 fun main() {
     val server = embeddedServer(Netty, port = 8080, module = Application::module)
@@ -44,6 +48,13 @@ fun Application.module() {
             jackson { applicationConfig() }
         }
     }
+
+    val varselService = VarselService(VarselRepository(), VarselProducer())
+
+    val consumers = listOf(
+        HendelseConsumer(varselService),
+    )
+    consumers.forEach { it.run() }
 
     configureRouting()
     configureMonitoring()

--- a/src/main/kotlin/no/nav/amt/distribusjon/Environment.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/Environment.kt
@@ -36,6 +36,8 @@ data class Environment(
         val appName: String = getEnvVar("NAIS_APP_NAME", "amt-distribusjon")
         val namespace: String = getEnvVar("NAIS_NAMESPACE", "amt")
 
+        val testContainersReuse = getEnvVar("TESTCONTAINERS_REUSE", "false").toBoolean()
+
         fun isDev(): Boolean {
             return cluster == "dev-gcp"
         }

--- a/src/main/kotlin/no/nav/amt/distribusjon/Environment.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/Environment.kt
@@ -29,13 +29,17 @@ data class Environment(
 
         const val HTTP_CLIENT_TIMEOUT_MS = 10_000
 
+        val DELTAKER_HENDELSE_TOPIC = "amt.deltaker-hendelse-v1"
+
+        val cluster: String = getEnvVar("NAIS_CLUSER_NAME", "lokal")
+        val appName: String = getEnvVar("NAIS_APP_NAME", "amt-distribusjon")
+        val namespace: String = getEnvVar("NAIS_NAMESPACE", "amt")
+
         fun isDev(): Boolean {
-            val cluster = System.getenv("NAIS_CLUSTER_NAME") ?: "Ikke dev"
             return cluster == "dev-gcp"
         }
 
         fun isProd(): Boolean {
-            val cluster = System.getenv("NAIS_CLUSTER_NAME") ?: "Ikke prod"
             return cluster == "prod-gcp"
         }
 

--- a/src/main/kotlin/no/nav/amt/distribusjon/Environment.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/Environment.kt
@@ -29,7 +29,8 @@ data class Environment(
 
         const val HTTP_CLIENT_TIMEOUT_MS = 10_000
 
-        val DELTAKER_HENDELSE_TOPIC = "amt.deltaker-hendelse-v1"
+        const val DELTAKER_HENDELSE_TOPIC = "amt.deltaker-hendelse-v1"
+        const val MINSIDE_VARSEL_TOPIC = "min-side.aapen-brukervarsel-v1"
 
         val cluster: String = getEnvVar("NAIS_CLUSER_NAME", "lokal")
         val appName: String = getEnvVar("NAIS_APP_NAME", "amt-distribusjon")

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseConsumer.kt
@@ -16,6 +16,7 @@ import java.util.UUID
 
 class HendelseConsumer(
     private val varselService: VarselService,
+    groupId: String = Environment.KAFKA_CONSUMER_GROUP_ID,
     kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
 ) : Consumer<UUID, String> {
     private val consumer = ManagedKafkaConsumer(
@@ -23,7 +24,7 @@ class HendelseConsumer(
         config = kafkaConfig.consumerConfig(
             keyDeserializer = UUIDDeserializer(),
             valueDeserializer = StringDeserializer(),
-            groupId = Environment.KAFKA_CONSUMER_GROUP_ID,
+            groupId = groupId,
         ),
         consume = ::consume,
     )

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseConsumer.kt
@@ -4,41 +4,33 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.amt.distribusjon.Environment
 import no.nav.amt.distribusjon.application.plugins.objectMapper
 import no.nav.amt.distribusjon.hendelse.model.Hendelse
-import no.nav.amt.distribusjon.hendelse.model.HendelseType
 import no.nav.amt.distribusjon.kafka.Consumer
 import no.nav.amt.distribusjon.kafka.ManagedKafkaConsumer
 import no.nav.amt.distribusjon.kafka.config.KafkaConfig
 import no.nav.amt.distribusjon.kafka.config.KafkaConfigImpl
 import no.nav.amt.distribusjon.kafka.config.LocalKafkaConfig
+import no.nav.amt.distribusjon.varsel.VarselService
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.UUIDDeserializer
 import java.util.UUID
 
 class HendelseConsumer(
+    private val varselService: VarselService,
     kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
 ) : Consumer<UUID, String> {
     private val consumer = ManagedKafkaConsumer(
         topic = Environment.DELTAKER_HENDELSE_TOPIC,
-        config = kafkaConfig.commonConfig(),
+        config = kafkaConfig.consumerConfig(
+            keyDeserializer = UUIDDeserializer(),
+            valueDeserializer = StringDeserializer(),
+            groupId = Environment.KAFKA_CONSUMER_GROUP_ID,
+        ),
         consume = ::consume,
     )
 
     override suspend fun consume(key: UUID, value: String) {
         val hendelse: Hendelse = objectMapper.readValue(value)
-
-        when (hendelse.payload) {
-            is HendelseType.AvbrytUtkast -> TODO()
-            is HendelseType.AvsluttDeltakelse -> TODO()
-            is HendelseType.EndreBakgrunnsinformasjon -> TODO()
-            is HendelseType.EndreDeltakelsesmengde -> TODO()
-            is HendelseType.EndreInnhold -> TODO()
-            is HendelseType.EndreSluttarsak -> TODO()
-            is HendelseType.EndreSluttdato -> TODO()
-            is HendelseType.EndreStartdato -> TODO()
-            is HendelseType.ForlengDeltakelse -> TODO()
-            is HendelseType.IkkeAktuell -> TODO()
-            is HendelseType.InnbyggerGodkjennUtkast -> TODO()
-            is HendelseType.NavGodkjennUtkast -> TODO()
-            is HendelseType.OpprettUtkast -> TODO()
-        }
+        varselService.handleHendelse(hendelse)
     }
 
     override fun run() = consumer.run()

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseConsumer.kt
@@ -1,0 +1,45 @@
+package no.nav.amt.distribusjon.hendelse
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.amt.distribusjon.Environment
+import no.nav.amt.distribusjon.application.plugins.objectMapper
+import no.nav.amt.distribusjon.hendelse.model.Hendelse
+import no.nav.amt.distribusjon.hendelse.model.HendelseType
+import no.nav.amt.distribusjon.kafka.Consumer
+import no.nav.amt.distribusjon.kafka.ManagedKafkaConsumer
+import no.nav.amt.distribusjon.kafka.config.KafkaConfig
+import no.nav.amt.distribusjon.kafka.config.KafkaConfigImpl
+import no.nav.amt.distribusjon.kafka.config.LocalKafkaConfig
+import java.util.UUID
+
+class HendelseConsumer(
+    kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
+) : Consumer<UUID, String> {
+    private val consumer = ManagedKafkaConsumer(
+        topic = Environment.DELTAKER_HENDELSE_TOPIC,
+        config = kafkaConfig.commonConfig(),
+        consume = ::consume,
+    )
+
+    override suspend fun consume(key: UUID, value: String) {
+        val hendelse: Hendelse = objectMapper.readValue(value)
+
+        when (hendelse.payload) {
+            is HendelseType.AvbrytUtkast -> TODO()
+            is HendelseType.AvsluttDeltakelse -> TODO()
+            is HendelseType.EndreBakgrunnsinformasjon -> TODO()
+            is HendelseType.EndreDeltakelsesmengde -> TODO()
+            is HendelseType.EndreInnhold -> TODO()
+            is HendelseType.EndreSluttarsak -> TODO()
+            is HendelseType.EndreSluttdato -> TODO()
+            is HendelseType.EndreStartdato -> TODO()
+            is HendelseType.ForlengDeltakelse -> TODO()
+            is HendelseType.IkkeAktuell -> TODO()
+            is HendelseType.InnbyggerGodkjennUtkast -> TODO()
+            is HendelseType.NavGodkjennUtkast -> TODO()
+            is HendelseType.OpprettUtkast -> TODO()
+        }
+    }
+
+    override fun run() = consumer.run()
+}

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/Hendelse.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/Hendelse.kt
@@ -1,0 +1,10 @@
+package no.nav.amt.distribusjon.hendelse.model
+
+import java.time.LocalDateTime
+
+data class Hendelse(
+    val opprettet: LocalDateTime,
+    val deltaker: HendelseDeltaker,
+    val ansvarlig: HendelseAnsvarlig,
+    val payload: HendelseType,
+)

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/HendelseAnsvarlig.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/HendelseAnsvarlig.kt
@@ -1,0 +1,25 @@
+package no.nav.amt.distribusjon.hendelse.model
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import java.util.UUID
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = HendelseAnsvarlig.NavVeileder::class, name = "NavVeileder"),
+)
+sealed interface HendelseAnsvarlig {
+    val navn: String
+
+    data class NavVeileder(
+        val id: UUID,
+        override val navn: String,
+        val navIdent: String,
+        val enhet: Enhet,
+    ) : HendelseAnsvarlig {
+        data class Enhet(
+            val id: UUID,
+            val enhetsnummer: String,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/HendelseDeltaker.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/HendelseDeltaker.kt
@@ -1,0 +1,41 @@
+package no.nav.amt.distribusjon.hendelse.model
+
+import java.util.UUID
+
+data class HendelseDeltaker(
+    val id: UUID,
+    val personident: String,
+    val deltakerliste: Deltakerliste,
+) {
+    data class Deltakerliste(
+        val id: UUID,
+        val navn: String,
+        val arrangor: Arrangor,
+        val tiltak: Tiltak,
+    ) {
+        data class Arrangor(
+            val id: UUID,
+            val organisasjonsnummer: String,
+            val navn: String,
+            val overordnetArrangor: Arrangor?,
+        )
+
+        data class Tiltak(
+            val navn: String,
+            val type: Type,
+            val ledetekst: String,
+        ) {
+            enum class Type {
+                INDOPPFAG,
+                ARBFORB,
+                AVKLARAG,
+                VASV,
+                ARBRRHDAG,
+                DIGIOPPARB,
+                JOBBK,
+                GRUPPEAMO,
+                GRUFAGYRKE,
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/HendelseType.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/HendelseType.kt
@@ -1,0 +1,113 @@
+package no.nav.amt.distribusjon.hendelse.model
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import java.time.LocalDate
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = HendelseType.EndreStartdato::class, name = "EndreStartdato"),
+    JsonSubTypes.Type(value = HendelseType.EndreSluttdato::class, name = "EndreSluttdato"),
+    JsonSubTypes.Type(value = HendelseType.EndreDeltakelsesmengde::class, name = "EndreDeltakelsesmengde"),
+    JsonSubTypes.Type(value = HendelseType.EndreBakgrunnsinformasjon::class, name = "EndreBakgrunnsinformasjon"),
+    JsonSubTypes.Type(value = HendelseType.EndreInnhold::class, name = "EndreInnhold"),
+    JsonSubTypes.Type(value = HendelseType.ForlengDeltakelse::class, name = "ForlengDeltakelse"),
+    JsonSubTypes.Type(value = HendelseType.EndreSluttarsak::class, name = "EndreSluttarsak"),
+    JsonSubTypes.Type(value = HendelseType.OpprettUtkast::class, name = "OpprettUtkast"),
+    JsonSubTypes.Type(value = HendelseType.AvbrytUtkast::class, name = "AvbrytUtkast"),
+    JsonSubTypes.Type(value = HendelseType.AvsluttDeltakelse::class, name = "AvsluttDeltakelse"),
+    JsonSubTypes.Type(value = HendelseType.IkkeAktuell::class, name = "IkkeAktuell"),
+    JsonSubTypes.Type(value = HendelseType.InnbyggerGodkjennUtkast::class, name = "InnbyggerGodkjennUtkast"),
+    JsonSubTypes.Type(value = HendelseType.NavGodkjennUtkast::class, name = "NavGodkjennUtkast"),
+)
+sealed interface HendelseType {
+    data class OpprettUtkast(
+        val utkast: Utkast,
+    ) : HendelseType
+
+    data class AvbrytUtkast(
+        val utkast: Utkast,
+    ) : HendelseType
+
+    data class InnbyggerGodkjennUtkast(
+        val utkast: Utkast,
+    ) : HendelseType
+
+    data class NavGodkjennUtkast(
+        val utkast: Utkast,
+    ) : HendelseType
+
+    data class EndreBakgrunnsinformasjon(
+        val bakgrunnsinformasjon: String?,
+    ) : HendelseType
+
+    data class EndreInnhold(
+        val innhold: List<Innhold>,
+    ) : HendelseType
+
+    data class EndreDeltakelsesmengde(
+        val deltakelsesprosent: Float?,
+        val dagerPerUke: Float?,
+    ) : HendelseType
+
+    data class EndreStartdato(
+        val startdato: LocalDate?,
+        val sluttdato: LocalDate? = null,
+    ) : HendelseType
+
+    data class EndreSluttdato(
+        val sluttdato: LocalDate,
+    ) : HendelseType
+
+    data class ForlengDeltakelse(
+        val sluttdato: LocalDate,
+    ) : HendelseType
+
+    data class IkkeAktuell(
+        val aarsak: Aarsak,
+    ) : HendelseType
+
+    data class AvsluttDeltakelse(
+        val aarsak: Aarsak,
+        val sluttdato: LocalDate,
+    ) : HendelseType
+
+    data class EndreSluttarsak(
+        val aarsak: Aarsak,
+    ) : HendelseType
+}
+
+data class Utkast(
+    val startdato: LocalDate?,
+    val sluttdato: LocalDate?,
+    val dagerPerUke: Float?,
+    val deltakelsesprosent: Float?,
+    val bakgrunnsinformasjon: String?,
+    val innhold: List<Innhold>,
+)
+
+data class Aarsak(
+    val type: Type,
+    val beskrivelse: String? = null,
+) {
+    init {
+        if (beskrivelse != null && type != Type.ANNET) {
+            error("Aarsak $type skal ikke ha beskrivelse")
+        }
+    }
+
+    enum class Type {
+        SYK,
+        FATT_JOBB,
+        TRENGER_ANNEN_STOTTE,
+        UTDANNING,
+        IKKE_MOTT,
+        ANNET,
+    }
+}
+
+data class Innhold(
+    val tekst: String,
+    val innholdskode: String,
+    val beskrivelse: String?,
+)

--- a/src/main/kotlin/no/nav/amt/distribusjon/kafka/Producer.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/kafka/Producer.kt
@@ -1,0 +1,24 @@
+package no.nav.amt.distribusjon.kafka
+
+import no.nav.amt.distribusjon.kafka.config.KafkaConfig
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+
+class Producer(private val kafkaConfig: KafkaConfig, private val topic: String) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun <K, V> produce(key: K, value: V) {
+        val record = ProducerRecord(topic, key, value)
+
+        KafkaProducer<K, V>(kafkaConfig.producerConfig()).use {
+            val metadata = it.send(record).get()
+            log.info(
+                "Produserte melding til topic ${metadata.topic()}, " +
+                    "key=${record.key()}, " +
+                    "offset=${metadata.offset()}, " +
+                    "partition=${metadata.partition()}",
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselProducer.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselProducer.kt
@@ -1,0 +1,49 @@
+package no.nav.amt.distribusjon.varsel
+
+import no.nav.amt.distribusjon.Environment
+import no.nav.amt.distribusjon.kafka.Producer
+import no.nav.amt.distribusjon.kafka.config.KafkaConfig
+import no.nav.amt.distribusjon.kafka.config.KafkaConfigImpl
+import no.nav.amt.distribusjon.kafka.config.LocalKafkaConfig
+import no.nav.amt.distribusjon.varsel.model.Varsel
+
+class VarselProducer(
+    kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
+) {
+    private val producer = Producer(kafkaConfig, Environment.MINSIDE_VARSEL_TOPIC)
+
+    private val skalTogglesAv = !Environment.isLocal()
+
+    fun inaktiver(varsel: Varsel) {
+        if (skalTogglesAv) return
+
+        producer.produce(
+            key = varsel.deltakerId.toString(),
+            value = varsel.toInaktiverDto(),
+        )
+    }
+
+    fun opprettOppgave(varsel: Varsel) {
+        if (skalTogglesAv) return
+
+        require(varsel.type == Varsel.Type.PAMELDING) {
+            "Kan ikke opprette oppgave, feil varseltype ${varsel.type}"
+        }
+
+        producer.produce(
+            key = varsel.deltakerId.toString(),
+            value = varsel.toOppgaveDto(true),
+        )
+    }
+
+    fun opprettBeskjed(varsel: Varsel) {
+        if (skalTogglesAv) return
+
+        val skalVarslesEksternt = varsel.type == Varsel.Type.PAMELDING || varsel.type == Varsel.Type.AVSLUTTNING
+
+        producer.produce(
+            key = varsel.deltakerId.toString(),
+            value = varsel.toBeskjedDto(skalVarslesEksternt),
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselProducer.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselProducer.kt
@@ -18,7 +18,7 @@ class VarselProducer(
         if (skalTogglesAv) return
 
         producer.produce(
-            key = varsel.deltakerId.toString(),
+            key = varsel.id.toString(),
             value = varsel.toInaktiverDto(),
         )
     }
@@ -31,7 +31,7 @@ class VarselProducer(
         }
 
         producer.produce(
-            key = varsel.deltakerId.toString(),
+            key = varsel.id.toString(),
             value = varsel.toOppgaveDto(true),
         )
     }
@@ -42,7 +42,7 @@ class VarselProducer(
         val skalVarslesEksternt = varsel.type == Varsel.Type.PAMELDING || varsel.type == Varsel.Type.AVSLUTTNING
 
         producer.produce(
-            key = varsel.deltakerId.toString(),
+            key = varsel.id.toString(),
             value = varsel.toBeskjedDto(skalVarslesEksternt),
         )
     }

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselProducer.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselProducer.kt
@@ -39,7 +39,7 @@ class VarselProducer(
     fun opprettBeskjed(varsel: Varsel) {
         if (skalTogglesAv) return
 
-        val skalVarslesEksternt = varsel.type == Varsel.Type.PAMELDING || varsel.type == Varsel.Type.AVSLUTTNING
+        val skalVarslesEksternt = varsel.type == Varsel.Type.PAMELDING || varsel.type == Varsel.Type.AVSLUTNING
 
         producer.produce(
             key = varsel.id.toString(),

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselRepository.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselRepository.kt
@@ -1,0 +1,60 @@
+package no.nav.amt.distribusjon.varsel
+
+import kotliquery.Row
+import kotliquery.queryOf
+import no.nav.amt.distribusjon.db.Database
+import no.nav.amt.distribusjon.varsel.model.Varsel
+import java.util.NoSuchElementException
+import java.util.UUID
+
+class VarselRepository {
+    fun rowmapper(row: Row) = Varsel(
+        id = row.uuid("id"),
+        type = Varsel.Type.valueOf(row.string("type")),
+        aktivFra = row.zonedDateTime("aktiv_fra"),
+        aktivTil = row.zonedDateTimeOrNull("aktiv_til"),
+        deltakerId = row.uuid("deltaker_id"),
+        personident = row.string("personident"),
+        tekst = row.string("tekst"),
+    )
+
+    fun upsert(varsel: Varsel) = Database.query {
+        val sql =
+            """
+            insert into varsel (id, type, aktiv_fra, aktiv_til, deltaker_id, personident)
+            values(:id, :type, :aktiv_fra, :aktiv_til, :deltaker_id, personident)
+            on conflict (id) do update set
+                aktiv_fra = :aktiv_fra,
+                aktiv_til = :aktiv_til
+                modified_at = current_timestamp
+            """.trimIndent()
+
+        val params = mapOf(
+            "id" to varsel.id,
+            "type" to varsel.type,
+            "aktiv_fra" to varsel.aktivFra,
+            "aktiv_til" to varsel.aktivTil,
+            "deltaker_id" to varsel.deltakerId,
+            "personident" to varsel.personident,
+        )
+
+        it.update(queryOf(sql, params))
+    }
+
+    fun getSisteVarsel(deltakerId: UUID, type: Varsel.Type) = Database.query {
+        val sql =
+            """
+            select * 
+            from varsel
+            where deltaker_id = :deltaker_id and type = :type
+            order by aktiv_fra desc
+            limit 1
+            """.trimIndent()
+
+        val query = queryOf(sql, mapOf("deltaker_id" to deltakerId, "type" to type.name))
+
+        it.run(query.map(::rowmapper).asSingle)?.let { varsel ->
+            Result.success(varsel)
+        } ?: Result.failure(NoSuchElementException(""))
+    }
+}

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselService.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselService.kt
@@ -34,7 +34,7 @@ class VarselService(
             is HendelseType.ForlengDeltakelse,
             is HendelseType.AvsluttDeltakelse,
             is HendelseType.IkkeAktuell,
-            -> opprettBeskjed(hendelse, Varsel.Type.AVSLUTTNING)
+            -> opprettBeskjed(hendelse, Varsel.Type.AVSLUTNING)
 
             is HendelseType.EndreStartdato,
             -> opprettBeskjed(hendelse, Varsel.Type.OPPSTART)

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselService.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselService.kt
@@ -1,0 +1,110 @@
+package no.nav.amt.distribusjon.varsel
+
+import no.nav.amt.distribusjon.hendelse.model.Hendelse
+import no.nav.amt.distribusjon.hendelse.model.HendelseDeltaker
+import no.nav.amt.distribusjon.hendelse.model.HendelseType
+import no.nav.amt.distribusjon.varsel.model.PAMELDING_TEKST
+import no.nav.amt.distribusjon.varsel.model.PLACEHOLDER_BESKJED_TEKST
+import no.nav.amt.distribusjon.varsel.model.Varsel
+import java.time.Duration
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.UUID
+
+class VarselService(
+    private val repository: VarselRepository,
+    private val producer: VarselProducer,
+) {
+    private val varselUtsettelse = Duration.ofHours(1)
+    private val beskjedAktivLengde = Duration.ofDays(14)
+
+    fun handleHendelse(hendelse: Hendelse) {
+        when (hendelse.payload) {
+            is HendelseType.OpprettUtkast -> opprettOppgave(hendelse, Varsel.Type.PAMELDING)
+            is HendelseType.AvbrytUtkast -> inaktiverVarsel(hendelse.deltaker, Varsel.Type.PAMELDING)
+            is HendelseType.InnbyggerGodkjennUtkast -> inaktiverVarsel(hendelse.deltaker, Varsel.Type.PAMELDING)
+            is HendelseType.NavGodkjennUtkast -> {
+                inaktiverVarsel(hendelse.deltaker, Varsel.Type.PAMELDING)
+                opprettBeskjed(hendelse, Varsel.Type.PAMELDING)
+            }
+
+            is HendelseType.EndreSluttdato,
+            is HendelseType.ForlengDeltakelse,
+            is HendelseType.AvsluttDeltakelse,
+            is HendelseType.IkkeAktuell,
+            -> opprettBeskjed(hendelse, Varsel.Type.AVSLUTTNING)
+
+            is HendelseType.EndreStartdato,
+            -> opprettBeskjed(hendelse, Varsel.Type.OPPSTART)
+
+            is HendelseType.EndreDeltakelsesmengde,
+            is HendelseType.EndreBakgrunnsinformasjon,
+            is HendelseType.EndreInnhold,
+            is HendelseType.EndreSluttarsak,
+            -> {
+            }
+        }
+    }
+
+    fun opprettBeskjed(hendelse: Hendelse, type: Varsel.Type) {
+        val forrigeVarsel = repository.getSisteVarsel(hendelse.deltaker.id, type).getOrNull()
+        repository.upsert(
+            nyttVarsel(
+                forrigeVarsel = forrigeVarsel,
+                type = type,
+                aktivTil = nowUTC().plus(beskjedAktivLengde),
+                tekst = PLACEHOLDER_BESKJED_TEKST,
+                hendelse = hendelse,
+            ),
+        )
+    }
+
+    fun opprettOppgave(hendelse: Hendelse, type: Varsel.Type) {
+        val forrigeVarsel = repository.getSisteVarsel(hendelse.deltaker.id, type).getOrNull()
+        repository.upsert(
+            nyttVarsel(
+                forrigeVarsel = forrigeVarsel,
+                type = type,
+                aktivTil = null,
+                tekst = PAMELDING_TEKST,
+                hendelse = hendelse,
+            ),
+        )
+    }
+
+    fun inaktiverVarsel(deltaker: HendelseDeltaker, type: Varsel.Type) {
+        repository.getSisteVarsel(deltaker.id, type).onSuccess { varsel ->
+            if (varsel.aktivTil != null && varsel.aktivTil > nowUTC()) {
+                producer.inaktiver(varsel)
+                repository.upsert(varsel.copy(aktivTil = nowUTC()))
+            }
+        }
+    }
+
+    private fun nyttVarsel(
+        forrigeVarsel: Varsel?,
+        type: Varsel.Type,
+        aktivTil: ZonedDateTime?,
+        tekst: String,
+        hendelse: Hendelse,
+    ): Varsel {
+        return if (forrigeVarsel != null && forrigeVarsel.aktivFra > nowUTC()) {
+            forrigeVarsel.copy(
+                aktivFra = nowUTC().plus(varselUtsettelse),
+                aktivTil = aktivTil,
+            )
+        } else {
+            Varsel(
+                id = UUID.randomUUID(),
+                type = type,
+                aktivFra = nowUTC().plus(varselUtsettelse),
+                aktivTil = aktivTil,
+                deltakerId = hendelse.deltaker.id,
+                personident = hendelse.deltaker.personident,
+                tekst = tekst,
+            )
+        }
+    }
+}
+
+fun nowUTC() = ZonedDateTime.now(ZoneId.of("Z"))

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/model/Varsel.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/model/Varsel.kt
@@ -23,7 +23,7 @@ data class Varsel(
     enum class Type {
         PAMELDING, // opprett-utkast, avbryt-utkast, godkjenn-utkast
         OPPSTART, // legg-til-oppstartsdato, endre-oppstartsdato
-        AVSLUTTNING, // avslutt-deltakelse, ikke-aktuell, forleng-deltakelse
+        AVSLUTNING, // avslutt-deltakelse, ikke-aktuell, forleng-deltakelse
 
         // deltakelsesmengde?
     }
@@ -41,7 +41,7 @@ data class Varsel(
 
     fun toBeskjedDto(skalVarslesEksternt: Boolean) = VarselActionBuilder.opprett {
         type = Varseltype.Beskjed
-        // link = innbyggerDeltakerUrl(deltakerId) // skal beskjeder ha link?
+        link = innbyggerDeltakerUrl(deltakerId) // skal beskjeder ha link?
         commonVarselConfig()
 
         if (skalVarslesEksternt) {

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/model/Varsel.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/model/Varsel.kt
@@ -1,0 +1,83 @@
+package no.nav.amt.distribusjon.varsel.model
+
+import no.nav.amt.distribusjon.Environment
+import no.nav.tms.varsel.action.EksternKanal
+import no.nav.tms.varsel.action.EksternVarslingBestilling
+import no.nav.tms.varsel.action.Produsent
+import no.nav.tms.varsel.action.Sensitivitet
+import no.nav.tms.varsel.action.Tekst
+import no.nav.tms.varsel.action.Varseltype
+import no.nav.tms.varsel.builder.VarselActionBuilder
+import java.time.ZonedDateTime
+import java.util.UUID
+
+data class Varsel(
+    val id: UUID,
+    val type: Type,
+    val aktivFra: ZonedDateTime,
+    val aktivTil: ZonedDateTime?,
+    val deltakerId: UUID,
+    val personident: String,
+    val tekst: String,
+) {
+    enum class Type {
+        PAMELDING, // opprett-utkast, avbryt-utkast, godkjenn-utkast
+        OPPSTART, // legg-til-oppstartsdato, endre-oppstartsdato
+        AVSLUTTNING, // avslutt-deltakelse, ikke-aktuell, forleng-deltakelse
+
+        // deltakelsesmengde?
+    }
+
+    fun toOppgaveDto(skalVarslesEksternt: Boolean) = VarselActionBuilder.opprett {
+        type = Varseltype.Oppgave
+        link = innbyggerDeltakerUrl(deltakerId)
+
+        commonVarselConfig()
+
+        if (skalVarslesEksternt) {
+            eksternVarsling = EksternVarslingBestilling(prefererteKanaler = listOf(EksternKanal.SMS))
+        }
+    }
+
+    fun toBeskjedDto(skalVarslesEksternt: Boolean) = VarselActionBuilder.opprett {
+        type = Varseltype.Beskjed
+        // link = innbyggerDeltakerUrl(deltakerId) // skal beskjeder ha link?
+        commonVarselConfig()
+
+        if (skalVarslesEksternt) {
+            eksternVarsling = EksternVarslingBestilling(prefererteKanaler = listOf(EksternKanal.SMS))
+        }
+    }
+
+    fun toInaktiverDto() = VarselActionBuilder.inaktiver {
+        varselId = this@Varsel.id.toString()
+        produsent = produsent()
+    }
+
+    private fun VarselActionBuilder.OpprettVarselInstance.commonVarselConfig() {
+        varselId = this@Varsel.id.toString()
+        sensitivitet = Sensitivitet.High
+        ident = personident
+        tekster += Tekst(
+            spraakkode = "nb",
+            tekst = this@Varsel.tekst,
+            default = true,
+        )
+        aktivFremTil = aktivTil
+        produsent = produsent()
+    }
+
+    private fun produsent() = Produsent(
+        cluster = Environment.cluster,
+        namespace = Environment.namespace,
+        appnavn = Environment.appName,
+    )
+}
+
+fun innbyggerDeltakerUrl(deltakerId: UUID): String {
+    return if (Environment.isProd()) {
+        "https://www.nav.no/arbeidsmarkedstiltak/$deltakerId"
+    } else {
+        "https://amt.intern.dev.nav.no/arbeidsmarkedstiltak/$deltakerId"
+    }
+}

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/model/VarselTekster.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/model/VarselTekster.kt
@@ -1,0 +1,5 @@
+package no.nav.amt.distribusjon.varsel.model
+
+const val PAMELDING_TEKST = "Svar på spørsmål om utkast til påmelding."
+
+const val PLACEHOLDER_BESKJED_TEKST = "Ny informasjon om ditt tiltak."

--- a/src/main/resources/db/migration/V01__varsel.sql
+++ b/src/main/resources/db/migration/V01__varsel.sql
@@ -1,0 +1,10 @@
+create table varsel
+(
+    id          uuid primary key,
+    type        varchar                  not null,
+    aktiv_fra   timestamp with time zone not null,
+    aktiv_til   timestamp with time zone,
+    deltaker_id uuid                     not null,
+    personident varchar                  not null,
+    tekst       varchar                  not null
+)

--- a/src/main/resources/db/migration/V01__varsel.sql
+++ b/src/main/resources/db/migration/V01__varsel.sql
@@ -1,10 +1,12 @@
 create table varsel
 (
     id          uuid primary key,
-    type        varchar                  not null,
-    aktiv_fra   timestamp with time zone not null,
+    type        varchar                                            not null,
+    aktiv_fra   timestamp with time zone                           not null,
     aktiv_til   timestamp with time zone,
-    deltaker_id uuid                     not null,
-    personident varchar                  not null,
-    tekst       varchar                  not null
+    deltaker_id uuid                                               not null,
+    personident varchar                                            not null,
+    tekst       varchar                                            not null,
+    created_at  timestamp with time zone default current_timestamp not null,
+    modified_at timestamp with time zone default current_timestamp not null
 )

--- a/src/test/kotlin/no/nav/amt/distribusjon/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/ApplicationTest.kt
@@ -3,19 +3,12 @@ package no.nav.amt.distribusjon
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.testing.testApplication
 import junit.framework.TestCase.assertEquals
-import no.nav.amt.distribusjon.application.plugins.configureRouting
-import no.nav.amt.distribusjon.application.plugins.configureSerialization
 import org.junit.Test
 
 class ApplicationTest {
     @Test
-    fun testRoot() = testApplication {
-        application {
-            configureSerialization()
-            configureRouting()
-        }
+    fun testRoot() = integrationTest { _, client ->
         client.get("/internal/health/liveness").apply {
             assertEquals(HttpStatusCode.OK, status)
             assertEquals("I'm alive!", bodyAsText())

--- a/src/test/kotlin/no/nav/amt/distribusjon/TestApp.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/TestApp.kt
@@ -1,0 +1,49 @@
+package no.nav.amt.distribusjon
+
+import io.ktor.client.HttpClient
+import io.ktor.server.testing.testApplication
+import no.nav.amt.distribusjon.application.isReadyKey
+import no.nav.amt.distribusjon.application.plugins.configureRouting
+import no.nav.amt.distribusjon.application.plugins.configureSerialization
+import no.nav.amt.distribusjon.hendelse.HendelseConsumer
+import no.nav.amt.distribusjon.kafka.config.LocalKafkaConfig
+import no.nav.amt.distribusjon.utils.SingletonKafkaProvider
+import no.nav.amt.distribusjon.utils.SingletonPostgresContainer
+import no.nav.amt.distribusjon.varsel.VarselProducer
+import no.nav.amt.distribusjon.varsel.VarselRepository
+import no.nav.amt.distribusjon.varsel.VarselService
+import java.util.UUID
+
+class TestApp {
+    val varselRepository: VarselRepository
+    val varselService: VarselService
+
+    init {
+        SingletonPostgresContainer.start()
+        SingletonKafkaProvider.start()
+
+        varselRepository = VarselRepository()
+        varselService = VarselService(varselRepository, VarselProducer(LocalKafkaConfig(SingletonKafkaProvider.getHost())))
+
+        val consumers = listOf(
+            HendelseConsumer(varselService, UUID.randomUUID().toString(), kafkaConfig = LocalKafkaConfig(SingletonKafkaProvider.getHost())),
+        )
+
+        consumers.forEach { it.run() }
+    }
+}
+
+private val testApp = TestApp()
+
+fun integrationTest(testBlock: suspend (app: TestApp, client: HttpClient) -> Unit) = testApplication {
+    application {
+        configureSerialization()
+
+        configureRouting()
+        // configureMonitoring()
+
+        attributes.put(isReadyKey, true)
+    }
+
+    testBlock(testApp, client)
+}

--- a/src/test/kotlin/no/nav/amt/distribusjon/hendelse/HendelseConsumerTest.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/hendelse/HendelseConsumerTest.kt
@@ -1,0 +1,191 @@
+package no.nav.amt.distribusjon.hendelse
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.time.delay
+import no.nav.amt.distribusjon.Environment
+import no.nav.amt.distribusjon.application.plugins.objectMapper
+import no.nav.amt.distribusjon.hendelse.model.Hendelse
+import no.nav.amt.distribusjon.integrationTest
+import no.nav.amt.distribusjon.utils.AsyncUtils
+import no.nav.amt.distribusjon.utils.assertProduced
+import no.nav.amt.distribusjon.utils.data.HendelseTypeData
+import no.nav.amt.distribusjon.utils.data.Hendelsesdata
+import no.nav.amt.distribusjon.utils.data.Varselsdata
+import no.nav.amt.distribusjon.utils.produceStringString
+import no.nav.amt.distribusjon.utils.shouldBeCloseTo
+import no.nav.amt.distribusjon.varsel.VarselService
+import no.nav.amt.distribusjon.varsel.model.PAMELDING_TEKST
+import no.nav.amt.distribusjon.varsel.model.PLACEHOLDER_BESKJED_TEKST
+import no.nav.amt.distribusjon.varsel.model.Varsel
+import no.nav.amt.distribusjon.varsel.nowUTC
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.junit.Test
+import java.time.Duration
+import java.util.UUID
+
+class HendelseConsumerTest {
+    @Test
+    fun `opprettUtkast - oppretter nytt varsel`() = integrationTest { app, _ ->
+        val hendelse = Hendelsesdata.hendelse(HendelseTypeData.opprettUtkast())
+
+        produce(hendelse)
+
+        AsyncUtils.eventually {
+            val varsel = app.varselRepository.getSisteVarsel(hendelse.deltaker.id, Varsel.Type.PAMELDING).getOrThrow()
+
+            varsel.aktivTil shouldBe null
+            varsel.tekst shouldBe PAMELDING_TEKST
+            varsel.aktivFra shouldBeCloseTo nowUTC().plusHours(1)
+            varsel.deltakerId shouldBe hendelse.deltaker.id
+            varsel.personident shouldBe hendelse.deltaker.personident
+        }
+    }
+
+    @Test
+    fun `opprettUtkast - varsel ikke sendt - utsetter varsel`() = integrationTest { app, _ ->
+        val hendelse = Hendelsesdata.hendelse(HendelseTypeData.opprettUtkast())
+        val forrigeVarsel = Varselsdata.varsel(
+            Varsel.Type.PAMELDING,
+            aktivFra = nowUTC().plusMinutes(30),
+            deltakerId = hendelse.deltaker.id,
+        )
+        app.varselRepository.upsert(forrigeVarsel)
+
+        produce(hendelse)
+
+        AsyncUtils.eventually {
+            val varsel = app.varselRepository.getSisteVarsel(hendelse.deltaker.id, Varsel.Type.PAMELDING).getOrThrow()
+
+            varsel.id shouldBe forrigeVarsel.id
+            varsel.aktivTil shouldBe null
+            varsel.tekst shouldBe forrigeVarsel.tekst
+            varsel.aktivFra shouldBeCloseTo nowUTC().plusHours(1)
+            varsel.deltakerId shouldBe forrigeVarsel.deltakerId
+            varsel.personident shouldBe forrigeVarsel.personident
+        }
+    }
+
+    @Test
+    fun `avbrytUtkast - varsel er aktivt - inaktiverer varsel og produserer`() = integrationTest { app, _ ->
+        val hendelse = Hendelsesdata.hendelse(HendelseTypeData.avbrytUtkast())
+        val forrigeVarsel = Varselsdata.varsel(
+            Varsel.Type.PAMELDING,
+            aktivFra = nowUTC().minusDays(1),
+            deltakerId = hendelse.deltaker.id,
+        )
+        app.varselRepository.upsert(forrigeVarsel)
+        produce(hendelse)
+
+        AsyncUtils.eventually {
+            val varsel = app.varselRepository.getSisteVarsel(hendelse.deltaker.id, Varsel.Type.PAMELDING).getOrThrow()
+
+            varsel.id shouldBe forrigeVarsel.id
+            varsel.aktivTil!! shouldBeCloseTo nowUTC()
+
+            assertProducedInaktiver(varsel.id)
+        }
+    }
+
+    @Test
+    fun `avbrytUtkast - varsel er ikke sendt - inaktiverer varsel og produserer ikke`() = integrationTest { app, _ ->
+        val hendelse = Hendelsesdata.hendelse(HendelseTypeData.avbrytUtkast())
+        val forrigeVarsel = Varselsdata.varsel(
+            Varsel.Type.PAMELDING,
+            aktivFra = nowUTC().plusHours(1),
+            deltakerId = hendelse.deltaker.id,
+        )
+        app.varselRepository.upsert(forrigeVarsel)
+        produce(hendelse)
+
+        AsyncUtils.eventually {
+            val varsel = app.varselRepository.getSisteVarsel(hendelse.deltaker.id, Varsel.Type.PAMELDING).getOrThrow()
+
+            varsel.id shouldBe forrigeVarsel.id
+            varsel.aktivTil!! shouldBeCloseTo nowUTC()
+        }
+        assertNotProduced(forrigeVarsel.id)
+    }
+
+    @Test
+    fun `innbyggerGodkjennerUtkast - inaktiverer varsel`() = integrationTest { app, _ ->
+        val hendelse = Hendelsesdata.hendelse(HendelseTypeData.innbyggerGodkjennUtkast())
+        val forrigeVarsel = Varselsdata.varsel(
+            Varsel.Type.PAMELDING,
+            aktivFra = nowUTC().minusDays(1),
+            deltakerId = hendelse.deltaker.id,
+        )
+        app.varselRepository.upsert(forrigeVarsel)
+        produce(hendelse)
+
+        AsyncUtils.eventually {
+            val varsel = app.varselRepository.getSisteVarsel(hendelse.deltaker.id, Varsel.Type.PAMELDING).getOrThrow()
+
+            varsel.id shouldBe forrigeVarsel.id
+            varsel.aktivTil!! shouldBeCloseTo nowUTC()
+
+            assertProducedInaktiver(varsel.id)
+        }
+    }
+
+    @Test
+    fun `navGodkjennUtkast - ingen tidligere varsel - oppretter beskjed`() = integrationTest { app, _ ->
+        val hendelse = Hendelsesdata.hendelse(HendelseTypeData.navGodkjennUtkast())
+
+        produce(hendelse)
+
+        AsyncUtils.eventually {
+            val varsel = app.varselRepository.getSisteVarsel(hendelse.deltaker.id, Varsel.Type.PAMELDING).getOrThrow()
+
+            varsel.aktivTil!! shouldBeCloseTo nowUTC().plus(VarselService.beskjedAktivLengde)
+            varsel.tekst shouldBe PLACEHOLDER_BESKJED_TEKST
+            varsel.aktivFra shouldBeCloseTo nowUTC().plusHours(1)
+            varsel.deltakerId shouldBe hendelse.deltaker.id
+            varsel.personident shouldBe hendelse.deltaker.personident
+        }
+    }
+
+    @Test
+    fun `navGodkjennUtkast - tidligere varsel - inaktiverer varsel og oppretter beskjed`() = integrationTest { app, _ ->
+        val hendelse = Hendelsesdata.hendelse(HendelseTypeData.navGodkjennUtkast())
+
+        val forrigeVarsel = Varselsdata.varsel(
+            Varsel.Type.PAMELDING,
+            aktivFra = nowUTC().minusDays(1),
+            deltakerId = hendelse.deltaker.id,
+        )
+        app.varselRepository.upsert(forrigeVarsel)
+        produce(hendelse)
+
+        AsyncUtils.eventually {
+            val beskjed = app.varselRepository.getSisteVarsel(hendelse.deltaker.id, Varsel.Type.PAMELDING).getOrThrow()
+
+            beskjed.aktivTil!! shouldBeCloseTo nowUTC().plus(VarselService.beskjedAktivLengde)
+            beskjed.tekst shouldBe PLACEHOLDER_BESKJED_TEKST
+            beskjed.aktivFra shouldBeCloseTo nowUTC().plusHours(1)
+            beskjed.deltakerId shouldBe hendelse.deltaker.id
+            beskjed.personident shouldBe hendelse.deltaker.personident
+
+            val inaktivertVarsel = app.varselRepository.get(forrigeVarsel.id).getOrThrow()
+            inaktivertVarsel.aktivTil!! shouldBeCloseTo nowUTC()
+
+            assertProducedInaktiver(forrigeVarsel.id)
+        }
+    }
+}
+
+private fun produce(hendelse: Hendelse) = produceStringString(
+    ProducerRecord(Environment.DELTAKER_HENDELSE_TOPIC, hendelse.deltaker.id.toString(), objectMapper.writeValueAsString(hendelse)),
+)
+
+private fun assertNotProduced(id: UUID) = assertProduced(Environment.MINSIDE_VARSEL_TOPIC) { cache ->
+    delay(Duration.ofMillis(1000))
+    cache[id] shouldBe null
+}
+
+private fun assertProducedInaktiver(id: UUID) = assertProduced(Environment.MINSIDE_VARSEL_TOPIC) {
+    AsyncUtils.eventually {
+        val json = objectMapper.readTree(it[id])
+        json["varselId"].asText() shouldBe id.toString()
+        json["@event_name"].asText() shouldBe "inaktiver"
+    }
+}

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/AsyncUtils.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/AsyncUtils.kt
@@ -1,14 +1,16 @@
 package no.nav.amt.distribusjon.utils
 
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.time.delay
 import java.time.Duration
 import java.time.LocalDateTime
 
 object AsyncUtils {
     fun eventually(
-        until: Duration = Duration.ofSeconds(10),
+        until: Duration = Duration.ofSeconds(3),
         interval: Duration = Duration.ofMillis(100),
         func: () -> Unit,
-    ) {
+    ) = runBlocking {
         val untilTime = LocalDateTime.now().plusNanos(until.toNanos())
 
         var throwable: Throwable = IllegalStateException()
@@ -16,10 +18,10 @@ object AsyncUtils {
         while (LocalDateTime.now().isBefore(untilTime)) {
             try {
                 func()
-                return
+                return@runBlocking
             } catch (t: Throwable) {
                 throwable = t
-                Thread.sleep(interval.toMillis())
+                delay(interval)
             }
         }
 

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/KafkaTestConsumers.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/KafkaTestConsumers.kt
@@ -1,0 +1,31 @@
+package no.nav.amt.distribusjon.utils
+
+import kotlinx.coroutines.runBlocking
+import no.nav.amt.distribusjon.kafka.ManagedKafkaConsumer
+import no.nav.amt.distribusjon.kafka.config.LocalKafkaConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import java.util.UUID
+
+fun stringStringConsumer(topic: String, block: suspend (k: String, v: String) -> Unit): ManagedKafkaConsumer<String, String> {
+    val config = LocalKafkaConfig(SingletonKafkaProvider.getHost(), "earliest").consumerConfig(
+        keyDeserializer = StringDeserializer(),
+        valueDeserializer = StringDeserializer(),
+        groupId = "test-consumer-${UUID.randomUUID()}",
+    )
+
+    return ManagedKafkaConsumer(topic, config, block)
+}
+
+fun assertProduced(topic: String, block: suspend (cache: Map<UUID, String>) -> Unit) {
+    val cache = mutableMapOf<UUID, String>()
+
+    val consumer = stringStringConsumer(topic) { k, v ->
+        cache[UUID.fromString(k)] = v
+    }
+
+    runBlocking {
+        consumer.run()
+        block(cache)
+        consumer.stop()
+    }
+}

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/KafkaTestProducers.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/KafkaTestProducers.kt
@@ -1,0 +1,20 @@
+package no.nav.amt.distribusjon.utils
+
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.serialization.StringSerializer
+import java.util.Properties
+
+fun produceStringString(record: ProducerRecord<String, String>): RecordMetadata {
+    KafkaProducer<String, String>(
+        Properties().apply {
+            put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, SingletonKafkaProvider.getHost())
+            put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java)
+            put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java)
+        },
+    ).use { producer ->
+        return producer.send(record).get()
+    }
+}

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/SingletonKafkaProvider.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/SingletonKafkaProvider.kt
@@ -1,0 +1,74 @@
+package no.nav.amt.distribusjon.utils
+
+import kotlinx.coroutines.runBlocking
+import no.nav.amt.distribusjon.Environment
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+object SingletonKafkaProvider {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private var kafkaContainer: KafkaContainer? = null
+
+    val topics = listOf(
+        Environment.DELTAKER_HENDELSE_TOPIC,
+        Environment.MINSIDE_VARSEL_TOPIC,
+    )
+
+    fun start() {
+        log.info("Starting new Kafka Instance...")
+        kafkaContainer = KafkaContainer(DockerImageName.parse(getKafkaImage()))
+        kafkaContainer!!.withReuse(Environment.testContainersReuse)
+        kafkaContainer!!.withLabel("reuse.UUID", "37b4361b-5adc-4de0-823b-f42cc00d7206")
+        kafkaContainer!!.start()
+
+        setupShutdownHook()
+        log.info("Kafka setup finished listening on ${kafkaContainer!!.bootstrapServers}.")
+    }
+
+    fun getHost(): String {
+        if (kafkaContainer == null) {
+            runBlocking { start() }
+        }
+        return kafkaContainer!!.bootstrapServers
+    }
+
+    private fun setupShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                log.info("Shutting down Kafka server...")
+                if (Environment.testContainersReuse) {
+                    cleanup()
+                } else {
+                    kafkaContainer?.stop()
+                }
+            },
+        )
+    }
+
+    fun cleanup() {
+        val adminClient = AdminClient.create(
+            mapOf(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG to kafkaContainer!!.bootstrapServers),
+        )
+        topics.forEach {
+            try {
+                adminClient.deleteTopics(listOf(it))
+                log.info("Deleted topic $it")
+            } catch (e: Exception) {
+                log.warn("Could not delete topic $it", e)
+            }
+        }
+        adminClient.close()
+    }
+
+    private fun getKafkaImage(): String {
+        val tag = when (System.getProperty("os.arch")) {
+            "aarch64" -> "7.6.0-2-ubi8.arm64"
+            else -> "7.6.0"
+        }
+
+        return "confluentinc/cp-kafka:$tag"
+    }
+}

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/SingletonPostgresContainer.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/SingletonPostgresContainer.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.distribusjon.utils
 
+import kotliquery.queryOf
 import no.nav.amt.distribusjon.Environment
 import no.nav.amt.distribusjon.db.Database
 import org.slf4j.LoggerFactory
@@ -29,6 +30,7 @@ object SingletonPostgresContainer {
             Database.init(Environment())
 
             setupShutdownHook()
+            log.info("Postgres setup finished")
         }
     }
 
@@ -43,6 +45,8 @@ object SingletonPostgresContainer {
     private fun createContainer(): PostgreSQLContainer<Nothing> {
         val container = PostgreSQLContainer<Nothing>(DockerImageName.parse(postgresDockerImageName).asCompatibleSubstituteFor("postgres"))
         container.addEnv("TZ", "Europe/Oslo")
+        container.withReuse(Environment.testContainersReuse)
+        container.withLabel("reuse.UUID", "dc04f4eb-01b6-4e32-b878-f0663d583a52")
         return container.waitingFor(HostPortWaitStrategy())
     }
 
@@ -50,10 +54,30 @@ object SingletonPostgresContainer {
         Runtime.getRuntime().addShutdownHook(
             Thread {
                 log.info("Shutting down postgres database...")
-                postgresContainer?.stop()
+                if (Environment.testContainersReuse) {
+                    cleanup()
+                } else {
+                    postgresContainer?.stop()
+                }
                 Database.close()
             },
         )
+    }
+
+    fun cleanup() = Database.query {
+        val tables = it.run(
+            queryOf("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'")
+                .map { it.string("table_name") }
+                .asList,
+        ).filterNot { table -> table == "flyway_schema_history" }
+
+        it.transaction { tx ->
+            tables.forEach { table ->
+                val sql = "truncate table $table cascade"
+                log.info("Truncating table $table...")
+                tx.run(queryOf(sql).asExecute)
+            }
+        }
     }
 
     private fun getPostgresImage(): String {

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Hendelsesdata.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Hendelsesdata.kt
@@ -1,0 +1,120 @@
+package no.nav.amt.distribusjon.utils.data
+
+import no.nav.amt.distribusjon.hendelse.model.Aarsak
+import no.nav.amt.distribusjon.hendelse.model.Hendelse
+import no.nav.amt.distribusjon.hendelse.model.HendelseAnsvarlig
+import no.nav.amt.distribusjon.hendelse.model.HendelseDeltaker
+import no.nav.amt.distribusjon.hendelse.model.HendelseType
+import no.nav.amt.distribusjon.hendelse.model.Innhold
+import no.nav.amt.distribusjon.hendelse.model.Utkast
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+object Hendelsesdata {
+    fun hendelse(
+        payload: HendelseType,
+        deltaker: HendelseDeltaker = deltaker(),
+        ansvarlig: HendelseAnsvarlig = ansvarligNavVeileder(),
+        opprettet: LocalDateTime = LocalDateTime.now(),
+    ) = Hendelse(
+        opprettet,
+        deltaker,
+        ansvarlig,
+        payload,
+    )
+
+    fun ansvarligNavVeileder(
+        id: UUID = UUID.randomUUID(),
+        navn: String = "Veilder Veildersen",
+        navIdent: String = randomNavIdent(),
+        enhet: HendelseAnsvarlig.NavVeileder.Enhet = ansvarligNavEnhet(),
+    ) = HendelseAnsvarlig.NavVeileder(id, navn, navIdent, enhet)
+
+    fun ansvarligNavEnhet(id: UUID = UUID.randomUUID(), enhetsnummer: String = randomEnhetsnummer()) =
+        HendelseAnsvarlig.NavVeileder.Enhet(id, enhetsnummer)
+
+    fun deltaker(
+        id: UUID = UUID.randomUUID(),
+        personident: String = randomIdent(),
+        deltakerliste: HendelseDeltaker.Deltakerliste = deltakerliste(),
+    ) = HendelseDeltaker(
+        id,
+        personident,
+        deltakerliste,
+    )
+
+    fun deltakerliste(
+        id: UUID = UUID.randomUUID(),
+        navn: String = "Deltakerlistenavn",
+        arrangor: HendelseDeltaker.Deltakerliste.Arrangor = arrangor(),
+        tiltak: HendelseDeltaker.Deltakerliste.Tiltak = tiltak(),
+    ) = HendelseDeltaker.Deltakerliste(id, navn, arrangor, tiltak)
+
+    fun arrangor(
+        id: UUID = UUID.randomUUID(),
+        organisasjonsnummer: String = randomOrgnr(),
+        navn: String = "Arrangornavn",
+        overordnetArrangor: HendelseDeltaker.Deltakerliste.Arrangor? = null,
+    ) = HendelseDeltaker.Deltakerliste.Arrangor(id, organisasjonsnummer, navn, overordnetArrangor)
+
+    fun tiltak(
+        navn: String = "Tiltaksnavn",
+        type: HendelseDeltaker.Deltakerliste.Tiltak.Type = HendelseDeltaker.Deltakerliste.Tiltak.Type.ARBFORB,
+        ledetekst: String = "Beskrivelse av hva tiltaket går ut på",
+    ) = HendelseDeltaker.Deltakerliste.Tiltak(navn, type, ledetekst)
+}
+
+object HendelseTypeData {
+    fun opprettUtkast(utkast: Utkast = utkast()) = HendelseType.OpprettUtkast(utkast)
+
+    fun avbrytUtkast(utkast: Utkast = utkast()) = HendelseType.AvbrytUtkast(utkast)
+
+    fun innbyggerGodkjennUtkast(utkast: Utkast = utkast()) = HendelseType.InnbyggerGodkjennUtkast(utkast)
+
+    fun navGodkjennUtkast(utkast: Utkast = utkast()) = HendelseType.NavGodkjennUtkast(utkast)
+
+    fun endreBakgrunnsinformasjon(bakgrunnsinformasjon: String = "Ny bakgrunn") =
+        HendelseType.EndreBakgrunnsinformasjon(bakgrunnsinformasjon)
+
+    fun endreInnhold(innhold: List<Innhold> = listOf(innhold())) = HendelseType.EndreInnhold(innhold)
+
+    fun endreDeltakelsesmengde(deltakelsesprosent: Float? = 99F, dagerPerUke: Float? = 5F) =
+        HendelseType.EndreDeltakelsesmengde(deltakelsesprosent, dagerPerUke)
+
+    fun endreStartdato(startdato: LocalDate? = LocalDate.now().plusDays(7), sluttdato: LocalDate? = null) =
+        HendelseType.EndreStartdato(startdato, sluttdato)
+
+    fun endreSluttdato(sluttdato: LocalDate = LocalDate.now().plusDays(7)) = HendelseType.EndreSluttdato(sluttdato)
+
+    fun forlengDeltakelse(sluttdato: LocalDate = LocalDate.now().plusMonths(2)) = HendelseType.ForlengDeltakelse(sluttdato)
+
+    fun ikkeAktuell(aarsak: Aarsak = Aarsak(Aarsak.Type.FATT_JOBB, null)) = HendelseType.IkkeAktuell(aarsak)
+
+    fun avsluttDeltakelse(aarsak: Aarsak = Aarsak(Aarsak.Type.FATT_JOBB, null), sluttdato: LocalDate = LocalDate.now().plusDays(7)) =
+        HendelseType.AvsluttDeltakelse(aarsak, sluttdato)
+
+    fun endreSluttarsak(aarsak: Aarsak = Aarsak(Aarsak.Type.ANNET, "Noe annet")) = HendelseType.EndreSluttarsak(aarsak)
+
+    fun utkast(
+        startdato: LocalDate? = null,
+        sluttdato: LocalDate? = null,
+        dagerPerUke: Float? = 4F,
+        deltakelsesprosent: Float = 80F,
+        bakgrunnsinformasjon: String = "Bakgrunn for deltakelse på tiltak",
+        innhold: List<Innhold> = listOf(innhold(), innhold(), innhold()),
+    ) = Utkast(
+        startdato,
+        sluttdato,
+        dagerPerUke,
+        deltakelsesprosent,
+        bakgrunnsinformasjon,
+        innhold,
+    )
+
+    fun innhold() = Innhold(
+        "Innholdstekst",
+        "Innholdskode",
+        "Beskrivelse av annet innhold",
+    )
+}

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/data/IdGeneratorer.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/data/IdGeneratorer.kt
@@ -1,0 +1,9 @@
+package no.nav.amt.distribusjon.utils.data
+
+fun randomOrgnr() = (900_000_000..999_999_998).random().toString()
+
+fun randomIdent() = (10_00_00_00_000..31_12_00_99_999).random().toString()
+
+fun randomNavIdent() = ('A'..'Z').random().toString() + (100_000..999_999).random().toString()
+
+fun randomEnhetsnummer() = (1_000..9_999_999).random().toString()

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Varselsdata.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Varselsdata.kt
@@ -1,0 +1,18 @@
+package no.nav.amt.distribusjon.utils.data
+
+import no.nav.amt.distribusjon.varsel.model.Varsel
+import no.nav.amt.distribusjon.varsel.nowUTC
+import java.time.ZonedDateTime
+import java.util.UUID
+
+object Varselsdata {
+    fun varsel(
+        type: Varsel.Type,
+        id: UUID = UUID.randomUUID(),
+        aktivFra: ZonedDateTime = nowUTC().plusHours(1),
+        aktivTil: ZonedDateTime? = null,
+        deltakerId: UUID = UUID.randomUUID(),
+        personident: String = randomIdent(),
+        tekst: String = "Varselstekst",
+    ) = Varsel(id, type, aktivFra, aktivTil, deltakerId, personident, tekst)
+}


### PR DESCRIPTION
Det er mange antakelser her som sikkert ikke stemmer.

Må ha en jobb for å produsere varsler etter forsinkelsen har utgått, eller vi må ha noe logikk som sier at vi sender ut varsler med engang på første hendelse også venter en tid til neste varsel sendes. Jeg legger opp til at en jobb kan kjøre og sende varsler etter en time har passert uten nye hendelse, men dette får vi endre på når vi lærer 🙂 

Jeg har forsøkt å legge til rette for et litt annerledes testoppsett denne gangen. Det største ønske mitt er at vi kan vedlikeholde `TestApp` og få den til å speile applikasjonen, slik at vi slipper å sette opp alle repositories og servicer i hver enkelt test, da blir det litt mindre endringer som må gjøres når man endrer på avhengigheter og slikt. Det kommer på bekosting av at det ikke er mulig å bruke `Mockk` sammens med denne, så der får man vurdere litt nytt når man kommer til at det er et behov.  

`TestApp` må spinne opp både en kafka og postgres, så bruker den et par sekunder lenger på å starte første test enn vanlig, derav hele regla om gjennbruk av TestContainers som står i readme. Gjennbruk har en del fallgruver med seg så det er ikke sikkert det er noe som bør brukes overalt, men det er veldig nice med litt raskere tester, så jeg tenker det er fint å kunne teste det ut litt her.