### PR TITLE
Send varsler umiddelbart hvis det ikke er et aktivt varsel fra før

### DIFF
--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselProducer.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselProducer.kt
@@ -26,7 +26,7 @@ class VarselProducer(
     fun opprettOppgave(varsel: Varsel) {
         if (skalTogglesAv) return
 
-        require(varsel.type == Varsel.Type.PAMELDING) {
+        require(varsel.type == Varsel.Type.OPPGAVE) {
             "Kan ikke opprette oppgave, feil varseltype ${varsel.type}"
         }
 
@@ -36,14 +36,12 @@ class VarselProducer(
         )
     }
 
-    fun opprettBeskjed(varsel: Varsel) {
+    fun opprettBeskjed(varsel: Varsel, skalVarsleEksternt: Boolean) {
         if (skalTogglesAv) return
-
-        val skalVarslesEksternt = varsel.type == Varsel.Type.PAMELDING || varsel.type == Varsel.Type.AVSLUTNING
 
         producer.produce(
             key = varsel.id.toString(),
-            value = varsel.toBeskjedDto(skalVarslesEksternt),
+            value = varsel.toBeskjedDto(skalVarsleEksternt),
         )
     }
 }

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselRepository.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselRepository.kt
@@ -17,13 +17,14 @@ class VarselRepository {
         deltakerId = row.uuid("deltaker_id"),
         personident = row.string("personident"),
         tekst = row.string("tekst"),
+        skalVarsleEksternt = row.boolean("skal_varsle_eksternt"),
     )
 
     fun upsert(varsel: Varsel) = Database.query {
         val sql =
             """
-            insert into varsel (id, type, tekst, aktiv_fra, aktiv_til, deltaker_id, personident)
-            values(:id, :type, :tekst, :aktiv_fra, :aktiv_til, :deltaker_id, :personident)
+            insert into varsel (id, type, tekst, aktiv_fra, aktiv_til, deltaker_id, personident, skal_varsle_eksternt)
+            values(:id, :type, :tekst, :aktiv_fra, :aktiv_til, :deltaker_id, :personident, :skal_varsle_eksternt)
             on conflict (id) do update set
                 aktiv_fra = :aktiv_fra,
                 aktiv_til = :aktiv_til,
@@ -38,6 +39,7 @@ class VarselRepository {
             "aktiv_til" to varsel.aktivTil,
             "deltaker_id" to varsel.deltakerId,
             "personident" to varsel.personident,
+            "skal_varsle_eksternt" to varsel.skalVarsleEksternt,
         )
 
         it.update(queryOf(sql, params))

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselRepository.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselRepository.kt
@@ -4,6 +4,7 @@ import kotliquery.Row
 import kotliquery.queryOf
 import no.nav.amt.distribusjon.db.Database
 import no.nav.amt.distribusjon.varsel.model.Varsel
+import java.time.ZoneId
 import java.util.NoSuchElementException
 import java.util.UUID
 
@@ -11,8 +12,8 @@ class VarselRepository {
     fun rowmapper(row: Row) = Varsel(
         id = row.uuid("id"),
         type = Varsel.Type.valueOf(row.string("type")),
-        aktivFra = row.zonedDateTime("aktiv_fra"),
-        aktivTil = row.zonedDateTimeOrNull("aktiv_til"),
+        aktivFra = row.zonedDateTime("aktiv_fra").withZoneSameInstant(ZoneId.of("Z")),
+        aktivTil = row.zonedDateTimeOrNull("aktiv_til")?.withZoneSameInstant(ZoneId.of("Z")),
         deltakerId = row.uuid("deltaker_id"),
         personident = row.string("personident"),
         tekst = row.string("tekst"),

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselService.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselService.kt
@@ -6,6 +6,7 @@ import no.nav.amt.distribusjon.hendelse.model.HendelseType
 import no.nav.amt.distribusjon.varsel.model.PAMELDING_TEKST
 import no.nav.amt.distribusjon.varsel.model.PLACEHOLDER_BESKJED_TEKST
 import no.nav.amt.distribusjon.varsel.model.Varsel
+import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -15,14 +16,15 @@ class VarselService(
     private val repository: VarselRepository,
     private val producer: VarselProducer,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     companion object {
-        val varselUtsettelse = Duration.ofHours(1)
         val beskjedAktivLengde = Duration.ofDays(14)
     }
 
     fun handleHendelse(hendelse: Hendelse) {
         when (hendelse.payload) {
-            is HendelseType.OpprettUtkast -> opprettOppgave(hendelse, Varsel.Type.PAMELDING)
+            is HendelseType.OpprettUtkast -> opprettPameldingsoppgave(hendelse)
             is HendelseType.AvbrytUtkast -> inaktiverVarsel(hendelse.deltaker, Varsel.Type.PAMELDING)
             is HendelseType.InnbyggerGodkjennUtkast -> inaktiverVarsel(hendelse.deltaker, Varsel.Type.PAMELDING)
             is HendelseType.NavGodkjennUtkast -> {
@@ -44,71 +46,69 @@ class VarselService(
             is HendelseType.EndreInnhold,
             is HendelseType.EndreSluttarsak,
             -> {
+                log.info("Oppretter ikke varsel for hendelse ${hendelse.payload::class} for deltaker ${hendelse.deltaker.id}")
             }
         }
     }
 
-    fun opprettBeskjed(hendelse: Hendelse, type: Varsel.Type) {
-        val forrigeVarsel = repository.getSisteVarsel(hendelse.deltaker.id, type).getOrNull()
-        repository.upsert(
-            nyttVarsel(
-                forrigeVarsel = forrigeVarsel,
-                type = type,
-                aktivTil = nowUTC().plus(beskjedAktivLengde),
-                tekst = PLACEHOLDER_BESKJED_TEKST,
-                hendelse = hendelse,
-            ),
-        )
-    }
+    private fun opprettBeskjed(hendelse: Hendelse, type: Varsel.Type) = opprettVarsel(
+        hendelse = hendelse,
+        type = type,
+        aktivTil = nowUTC().plus(beskjedAktivLengde),
+        tekst = PLACEHOLDER_BESKJED_TEKST,
+    )
 
-    fun opprettOppgave(hendelse: Hendelse, type: Varsel.Type) {
+    private fun opprettPameldingsoppgave(hendelse: Hendelse) = opprettVarsel(
+        hendelse = hendelse,
+        type = Varsel.Type.PAMELDING,
+        aktivTil = null,
+        tekst = PAMELDING_TEKST,
+    )
+
+    private fun opprettVarsel(
+        hendelse: Hendelse,
+        type: Varsel.Type,
+        aktivTil: ZonedDateTime?,
+        tekst: String,
+    ) {
         val forrigeVarsel = repository.getSisteVarsel(hendelse.deltaker.id, type).getOrNull()
-        repository.upsert(
-            nyttVarsel(
-                forrigeVarsel = forrigeVarsel,
-                type = type,
-                aktivTil = null,
-                tekst = PAMELDING_TEKST,
-                hendelse = hendelse,
-            ),
+        if (forrigeVarsel?.erAktiv == true) {
+            // Nå kan det hende at en beskjed har blitt inaktivert av innbygger uten at vi har fått vite om det.
+            // For å vite dette kan vi lytte på aapen-varsel-hendelse-v1 for å få oppdateringer om status på varseler.
+            log.info(
+                "Forrige varsel for deltaker ${hendelse.deltaker.id} av type $type er fortsatt aktivt. " +
+                    "Oppretter ikke nytt varsel.",
+            )
+            return
+        }
+
+        val varsel = Varsel(
+            id = UUID.randomUUID(),
+            type = type,
+            aktivFra = nowUTC(),
+            aktivTil = aktivTil,
+            deltakerId = hendelse.deltaker.id,
+            personident = hendelse.deltaker.personident,
+            tekst = tekst,
         )
+
+        repository.upsert(varsel)
+
+        log.info("Opprettet varsel for deltaker ${hendelse.deltaker.id} av type $type")
+
+        when (type) {
+            Varsel.Type.PAMELDING -> producer.opprettOppgave(varsel)
+            Varsel.Type.OPPSTART -> producer.opprettBeskjed(varsel)
+            Varsel.Type.AVSLUTNING -> producer.opprettBeskjed(varsel)
+        }
     }
 
     fun inaktiverVarsel(deltaker: HendelseDeltaker, type: Varsel.Type) {
         repository.getSisteVarsel(deltaker.id, type).onSuccess { varsel ->
-            val now = nowUTC()
-            if (varsel.aktivTil == null || varsel.aktivTil > now) {
-                repository.upsert(varsel.copy(aktivTil = now))
-
-                if (varsel.aktivFra < now) {
-                    producer.inaktiver(varsel)
-                }
+            if (varsel.erAktiv) {
+                repository.upsert(varsel.copy(aktivTil = nowUTC()))
+                producer.inaktiver(varsel)
             }
-        }
-    }
-
-    private fun nyttVarsel(
-        forrigeVarsel: Varsel?,
-        type: Varsel.Type,
-        aktivTil: ZonedDateTime?,
-        tekst: String,
-        hendelse: Hendelse,
-    ): Varsel {
-        return if (forrigeVarsel != null && forrigeVarsel.aktivFra > nowUTC()) {
-            forrigeVarsel.copy(
-                aktivFra = nowUTC().plus(varselUtsettelse),
-                aktivTil = aktivTil,
-            )
-        } else {
-            Varsel(
-                id = UUID.randomUUID(),
-                type = type,
-                aktivFra = nowUTC().plus(varselUtsettelse),
-                aktivTil = aktivTil,
-                deltakerId = hendelse.deltaker.id,
-                personident = hendelse.deltaker.personident,
-                tekst = tekst,
-            )
         }
     }
 }

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/model/Varsel.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/model/Varsel.kt
@@ -20,6 +20,7 @@ data class Varsel(
     val deltakerId: UUID,
     val personident: String,
     val tekst: String,
+    val skalVarsleEksternt: Boolean,
 ) {
     val erAktiv: Boolean get() {
         val now = nowUTC()
@@ -27,11 +28,8 @@ data class Varsel(
     }
 
     enum class Type {
-        PAMELDING, // opprett-utkast, avbryt-utkast, godkjenn-utkast
-        OPPSTART, // legg-til-oppstartsdato, endre-oppstartsdato
-        AVSLUTNING, // avslutt-deltakelse, ikke-aktuell, forleng-deltakelse
-
-        // deltakelsesmengde?
+        BESKJED,
+        OPPGAVE,
     }
 
     fun toOppgaveDto(skalVarslesEksternt: Boolean) = VarselActionBuilder.opprett {

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/model/Varsel.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/model/Varsel.kt
@@ -1,6 +1,7 @@
 package no.nav.amt.distribusjon.varsel.model
 
 import no.nav.amt.distribusjon.Environment
+import no.nav.amt.distribusjon.varsel.nowUTC
 import no.nav.tms.varsel.action.EksternKanal
 import no.nav.tms.varsel.action.EksternVarslingBestilling
 import no.nav.tms.varsel.action.Produsent
@@ -20,6 +21,11 @@ data class Varsel(
     val personident: String,
     val tekst: String,
 ) {
+    val erAktiv: Boolean get() {
+        val now = nowUTC()
+        return aktivFra <= now && (aktivTil == null || aktivTil >= now)
+    }
+
     enum class Type {
         PAMELDING, // opprett-utkast, avbryt-utkast, godkjenn-utkast
         OPPSTART, // legg-til-oppstartsdato, endre-oppstartsdato

--- a/src/main/resources/db/migration/V02__varsel-ekstern.sql
+++ b/src/main/resources/db/migration/V02__varsel-ekstern.sql
@@ -1,0 +1,1 @@
+alter table varsel add column skal_varsle_eksternt boolean default false;

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Varselsdata.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Varselsdata.kt
@@ -14,5 +14,6 @@ object Varselsdata {
         deltakerId: UUID = UUID.randomUUID(),
         personident: String = randomIdent(),
         tekst: String = "Varselstekst",
-    ) = Varsel(id, type, aktivFra, aktivTil, deltakerId, personident, tekst)
+        skalVarsleEksternt: Boolean = if (type == Varsel.Type.OPPGAVE) true else false,
+    ) = Varsel(id, type, aktivFra, aktivTil, deltakerId, personident, tekst, skalVarsleEksternt)
 }


### PR DESCRIPTION
Jeg tenker det gir mer mening at vi sender varslene med engang så lenge det ikke er noen varsler som er aktive fra før. I allefall for testingen sin del er det kjedelig å måtte vente for å kunne sjekke varslingen. 

Jeg tenker vi må vurdere litt hvordan vi ønsker å gjøre det med ekstern varsling. Det er vel i det minste litt kjipt å sende SMSer midt på natta. Kanskje vi kan sette en begrensing på max 1 eksternvarsling om dagen. Men det blir lettere å finne ut av når vi får testet litt mer. 

Jeg har bedt om tilgang til topicene hos min-side, så jeg venter med å endre togglene til den er merget.