### PR TITLE
logikk for hendelser som ikke skal journalføres

### DIFF
--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseRepository.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseRepository.kt
@@ -52,8 +52,8 @@ class HendelseRepository {
             from hendelse h
                 left join journalforingstatus js on h.id = js.hendelse_id
             where h.created_at < :opprettet 
+                and js.hendelse_id is not null
                 and js.journalpost_id is null
-                and js.skal_journalfores = true
             """.trimIndent()
 
         val query = queryOf(sql, mapOf("opprettet" to opprettet))

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseRepository.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseRepository.kt
@@ -44,14 +44,16 @@ class HendelseRepository {
         val sql =
             """
             select h.id as "id",
-            h.deltaker as "deltaker",
-            h.ansvarlig as "ansvarlig",
-            h.payload as "payload",
-            h.created_at as "h.created_at",
-            h.distribusjonskanal as "distribusjonskanal"
+                h.deltaker as "deltaker",
+                h.ansvarlig as "ansvarlig",
+                h.payload as "payload",
+                h.created_at as "h.created_at",
+                h.distribusjonskanal as "distribusjonskanal"
             from hendelse h
-            left join journalforingstatus js on h.id = js.hendelse_id
-            where h.created_at < :opprettet and js.hendelse_id is null
+                left join journalforingstatus js on h.id = js.hendelse_id
+            where h.created_at < :opprettet 
+                and js.journalpost_id is null
+                and js.skal_journalfores = true
             """.trimIndent()
 
         val query = queryOf(sql, mapOf("opprettet" to opprettet))

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingService.kt
@@ -56,7 +56,8 @@ class JournalforingService(
             is HendelseType.EndreUtkast,
             is HendelseType.OpprettUtkast,
             is HendelseType.AvbrytUtkast,
-            -> handleEndringSomIkkeJournalfores(hendelse)
+            -> {
+            }
         }
     }
 
@@ -89,7 +90,6 @@ class JournalforingService(
             Journalforingstatus(
                 hendelseId = hendelseId,
                 journalpostId = journalpostId,
-                skalJournalfores = true,
             ),
         )
 
@@ -101,21 +101,9 @@ class JournalforingService(
             Journalforingstatus(
                 hendelseId = hendelse.id,
                 journalpostId = null,
-                skalJournalfores = true,
             ),
         )
         log.info("Endringsvedtak for hendelse ${hendelse.id} er lagret og plukkes opp av asynkron jobb")
-    }
-
-    private fun handleEndringSomIkkeJournalfores(hendelse: Hendelse) {
-        journalforingstatusRepository.upsert(
-            Journalforingstatus(
-                hendelseId = hendelse.id,
-                journalpostId = null,
-                skalJournalfores = false,
-            ),
-        )
-        log.info("Hendelse ${hendelse.id} skal ikke journalføres")
     }
 
     suspend fun journalforEndringsvedtak(hendelser: List<Hendelse>) {
@@ -161,7 +149,6 @@ class JournalforingService(
                 Journalforingstatus(
                     hendelseId = it,
                     journalpostId = journalpostId,
-                    skalJournalfores = true,
                 ),
             )
         }
@@ -173,7 +160,7 @@ class JournalforingService(
 
     private fun hendelseErBehandlet(hendelseId: UUID): Boolean {
         val journalforingstatus = journalforingstatusRepository.get(hendelseId)
-        return journalforingstatus != null && (journalforingstatus.journalpostId != null || !journalforingstatus.skalJournalfores)
+        return journalforingstatus?.journalpostId != null
     }
 
     private fun fjernEldreHendelserAvSammeType(hendelser: List<Hendelse>): List<Hendelse> {

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingstatusRepository.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingstatusRepository.kt
@@ -10,24 +10,21 @@ class JournalforingstatusRepository {
     private fun rowmapper(row: Row) = Journalforingstatus(
         hendelseId = row.uuid("hendelse_id"),
         journalpostId = row.stringOrNull("journalpost_id"),
-        skalJournalfores = row.boolean("skal_journalfores"),
     )
 
     fun upsert(journalforingstatus: Journalforingstatus) = Database.query {
         val sql =
             """
-            insert into journalforingstatus (hendelse_id, journalpost_id, skal_journalfores)
-            values(:hendelse_id, :journalpost_id, :skal_journalfores)
+            insert into journalforingstatus (hendelse_id, journalpost_id)
+            values(:hendelse_id, :journalpost_id)
             on conflict (hendelse_id) do update set
                 journalpost_id = :journalpost_id,
-                skal_journalfores = :skal_journalfores,
                 modified_at = current_timestamp
             """.trimIndent()
 
         val params = mapOf(
             "hendelse_id" to journalforingstatus.hendelseId,
             "journalpost_id" to journalforingstatus.journalpostId,
-            "skal_journalfores" to journalforingstatus.skalJournalfores,
         )
 
         it.update(queryOf(sql, params))

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingstatusRepository.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingstatusRepository.kt
@@ -9,19 +9,25 @@ import java.util.UUID
 class JournalforingstatusRepository {
     private fun rowmapper(row: Row) = Journalforingstatus(
         hendelseId = row.uuid("hendelse_id"),
-        journalpostId = row.string("journalpost_id"),
+        journalpostId = row.stringOrNull("journalpost_id"),
+        skalJournalfores = row.boolean("skal_journalfores"),
     )
 
-    fun insert(journalforingstatus: Journalforingstatus) = Database.query {
+    fun upsert(journalforingstatus: Journalforingstatus) = Database.query {
         val sql =
             """
-            insert into journalforingstatus (hendelse_id, journalpost_id)
-            values(:hendelse_id, :journalpost_id)
+            insert into journalforingstatus (hendelse_id, journalpost_id, skal_journalfores)
+            values(:hendelse_id, :journalpost_id, :skal_journalfores)
+            on conflict (hendelse_id) do update set
+                journalpost_id = :journalpost_id,
+                skal_journalfores = :skal_journalfores,
+                modified_at = current_timestamp
             """.trimIndent()
 
         val params = mapOf(
             "hendelse_id" to journalforingstatus.hendelseId,
             "journalpost_id" to journalforingstatus.journalpostId,
+            "skal_journalfores" to journalforingstatus.skalJournalfores,
         )
 
         it.update(queryOf(sql, params))

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/model/Journalforingstatus.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/model/Journalforingstatus.kt
@@ -4,5 +4,6 @@ import java.util.UUID
 
 data class Journalforingstatus(
     val hendelseId: UUID,
-    val journalpostId: String,
+    val journalpostId: String?,
+    val skalJournalfores: Boolean,
 )

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/model/Journalforingstatus.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/model/Journalforingstatus.kt
@@ -5,5 +5,4 @@ import java.util.UUID
 data class Journalforingstatus(
     val hendelseId: UUID,
     val journalpostId: String?,
-    val skalJournalfores: Boolean,
 )

--- a/src/main/resources/db/migration/V07__journalforingstatus-add-columns.sql
+++ b/src/main/resources/db/migration/V07__journalforingstatus-add-columns.sql
@@ -1,0 +1,5 @@
+alter table journalforingstatus add column skal_journalfores boolean not null default false;
+alter table journalforingstatus add column modified_at timestamp with time zone default current_timestamp not null;
+
+alter table journalforingstatus alter column skal_journalfores drop default;
+alter table journalforingstatus alter column journalpost_id drop not null;

--- a/src/main/resources/db/migration/V07__journalforingstatus-add-columns.sql
+++ b/src/main/resources/db/migration/V07__journalforingstatus-add-columns.sql
@@ -1,5 +1,3 @@
-alter table journalforingstatus add column skal_journalfores boolean not null default false;
 alter table journalforingstatus add column modified_at timestamp with time zone default current_timestamp not null;
 
-alter table journalforingstatus alter column skal_journalfores drop default;
 alter table journalforingstatus alter column journalpost_id drop not null;

--- a/src/test/kotlin/no/nav/amt/distribusjon/hendelse/HendelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/hendelse/HendelseRepositoryTest.kt
@@ -39,7 +39,6 @@ class HendelseRepositoryTest {
             Journalforingstatus(
                 hendelse.id,
                 null,
-                true,
             ),
         )
 
@@ -57,7 +56,6 @@ class HendelseRepositoryTest {
             Journalforingstatus(
                 hendelse.id,
                 null,
-                true,
             ),
         )
 
@@ -74,24 +72,6 @@ class HendelseRepositoryTest {
             Journalforingstatus(
                 hendelse.id,
                 "12345",
-                true,
-            ),
-        )
-
-        val ikkeJournalforteHendelser = hendelseRepository.getIkkeJournalforteHendelser(LocalDateTime.now())
-
-        ikkeJournalforteHendelser.size shouldBe 0
-    }
-
-    @Test
-    fun `getIkkeJournalforteHendelser - hendelse skal ikke journalfores - returnerer tom liste`() {
-        val hendelse = Hendelsesdata.hendelse(HendelseTypeData.forlengDeltakelse(), opprettet = LocalDateTime.now().minusHours(1))
-        TestRepository.insert(hendelse)
-        journalforingstatusRepository.upsert(
-            Journalforingstatus(
-                hendelse.id,
-                null,
-                false,
             ),
         )
 

--- a/src/test/kotlin/no/nav/amt/distribusjon/hendelse/HendelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/hendelse/HendelseRepositoryTest.kt
@@ -35,6 +35,13 @@ class HendelseRepositoryTest {
     fun `getIkkeJournalforteHendelser - hendelse er ikke journalfort - returnerer hendelse`() {
         val hendelse = Hendelsesdata.hendelse(HendelseTypeData.forlengDeltakelse(), opprettet = LocalDateTime.now().minusHours(1))
         TestRepository.insert(hendelse)
+        journalforingstatusRepository.upsert(
+            Journalforingstatus(
+                hendelse.id,
+                null,
+                true,
+            ),
+        )
 
         val ikkeJournalforteHendelser = hendelseRepository.getIkkeJournalforteHendelser(LocalDateTime.now())
 
@@ -46,6 +53,13 @@ class HendelseRepositoryTest {
     fun `getIkkeJournalforteHendelser - hendelse er ikke journalfort, tidspunkt ikke passert - returnerer tom liste`() {
         val hendelse = Hendelsesdata.hendelse(HendelseTypeData.forlengDeltakelse(), opprettet = LocalDateTime.now())
         TestRepository.insert(hendelse)
+        journalforingstatusRepository.upsert(
+            Journalforingstatus(
+                hendelse.id,
+                null,
+                true,
+            ),
+        )
 
         val ikkeJournalforteHendelser = hendelseRepository.getIkkeJournalforteHendelser(LocalDateTime.now().minusHours(1))
 
@@ -56,12 +70,40 @@ class HendelseRepositoryTest {
     fun `getIkkeJournalforteHendelser - hendelse er journalfort - returnerer tom liste`() {
         val hendelse = Hendelsesdata.hendelse(HendelseTypeData.forlengDeltakelse(), opprettet = LocalDateTime.now().minusHours(1))
         TestRepository.insert(hendelse)
-        journalforingstatusRepository.insert(
+        journalforingstatusRepository.upsert(
             Journalforingstatus(
                 hendelse.id,
                 "12345",
+                true,
             ),
         )
+
+        val ikkeJournalforteHendelser = hendelseRepository.getIkkeJournalforteHendelser(LocalDateTime.now())
+
+        ikkeJournalforteHendelser.size shouldBe 0
+    }
+
+    @Test
+    fun `getIkkeJournalforteHendelser - hendelse skal ikke journalfores - returnerer tom liste`() {
+        val hendelse = Hendelsesdata.hendelse(HendelseTypeData.forlengDeltakelse(), opprettet = LocalDateTime.now().minusHours(1))
+        TestRepository.insert(hendelse)
+        journalforingstatusRepository.upsert(
+            Journalforingstatus(
+                hendelse.id,
+                null,
+                false,
+            ),
+        )
+
+        val ikkeJournalforteHendelser = hendelseRepository.getIkkeJournalforteHendelser(LocalDateTime.now())
+
+        ikkeJournalforteHendelser.size shouldBe 0
+    }
+
+    @Test
+    fun `getIkkeJournalforteHendelser - journalforingstatus finnes ikke - returnerer tom liste`() {
+        val hendelse = Hendelsesdata.hendelse(HendelseTypeData.forlengDeltakelse(), opprettet = LocalDateTime.now().minusHours(1))
+        TestRepository.insert(hendelse)
 
         val ikkeJournalforteHendelser = hendelseRepository.getIkkeJournalforteHendelser(LocalDateTime.now())
 

--- a/src/test/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingServiceTest.kt
@@ -64,7 +64,7 @@ class JournalforingServiceTest {
         runBlocking {
             journalforingService.handleHendelse(hendelse)
 
-            journalforingstatusRepository.get(hendelse.id) shouldBe Journalforingstatus(hendelse.id, "12345", true)
+            journalforingstatusRepository.get(hendelse.id) shouldBe Journalforingstatus(hendelse.id, "12345")
 
             coVerify {
                 dokarkivClient.opprettJournalpost(
@@ -83,7 +83,7 @@ class JournalforingServiceTest {
     @Test
     fun `handleHendelse - InnbyggerGodkjennUtkast, er allerede journalfort - ignorerer hendelse`() {
         val hendelse = Hendelsesdata.hendelse(HendelseTypeData.innbyggerGodkjennUtkast())
-        journalforingstatusRepository.upsert(Journalforingstatus(hendelse.id, "12345", true))
+        journalforingstatusRepository.upsert(Journalforingstatus(hendelse.id, "12345"))
 
         runBlocking {
             journalforingService.handleHendelse(hendelse)
@@ -119,7 +119,7 @@ class JournalforingServiceTest {
         runBlocking {
             journalforingService.handleHendelse(hendelse)
 
-            journalforingstatusRepository.get(hendelse.id) shouldBe Journalforingstatus(hendelse.id, null, false)
+            journalforingstatusRepository.get(hendelse.id) shouldBe null
 
             coVerify(exactly = 0) { dokarkivClient.opprettJournalpost(any(), any(), any(), any(), any(), any(), any()) }
         }
@@ -140,22 +140,22 @@ class JournalforingServiceTest {
             deltaker = deltaker,
             opprettet = LocalDateTime.now().minusMinutes(20),
         )
-        journalforingstatusRepository.upsert(Journalforingstatus(hendelseDeltakelsesmengde.id, null, true))
+        journalforingstatusRepository.upsert(Journalforingstatus(hendelseDeltakelsesmengde.id, null))
         val hendelseForleng = Hendelsesdata.hendelse(
             HendelseTypeData.forlengDeltakelse(),
             deltaker = deltaker,
             ansvarlig = ansvarligNavVeileder,
             opprettet = LocalDateTime.now(),
         )
-        journalforingstatusRepository.upsert(Journalforingstatus(hendelseForleng.id, null, true))
+        journalforingstatusRepository.upsert(Journalforingstatus(hendelseForleng.id, null))
 
         runBlocking {
             journalforingService.journalforEndringsvedtak(listOf(hendelseForleng, hendelseDeltakelsesmengde))
 
             journalforingstatusRepository.get(
                 hendelseDeltakelsesmengde.id,
-            ) shouldBe Journalforingstatus(hendelseDeltakelsesmengde.id, "12345", true)
-            journalforingstatusRepository.get(hendelseForleng.id) shouldBe Journalforingstatus(hendelseForleng.id, "12345", true)
+            ) shouldBe Journalforingstatus(hendelseDeltakelsesmengde.id, "12345")
+            journalforingstatusRepository.get(hendelseForleng.id) shouldBe Journalforingstatus(hendelseForleng.id, "12345")
 
             coVerify { pdfgenClient.endringsvedtak(match { it.endringer.size == 2 }) }
             coVerify {
@@ -188,20 +188,20 @@ class JournalforingServiceTest {
             ansvarlig = ansvarligNavVeileder,
             opprettet = LocalDateTime.now().minusMinutes(20),
         )
-        journalforingstatusRepository.upsert(Journalforingstatus(hendelse1.id, null, true))
+        journalforingstatusRepository.upsert(Journalforingstatus(hendelse1.id, null))
         val hendelse2 = Hendelsesdata.hendelse(
             HendelseTypeData.forlengDeltakelse(sluttdato = LocalDate.now().plusWeeks(4)),
             deltaker = deltaker,
             ansvarlig = ansvarligNavVeileder,
             opprettet = LocalDateTime.now(),
         )
-        journalforingstatusRepository.upsert(Journalforingstatus(hendelse2.id, null, true))
+        journalforingstatusRepository.upsert(Journalforingstatus(hendelse2.id, null))
 
         runBlocking {
             journalforingService.journalforEndringsvedtak(listOf(hendelse1, hendelse2))
 
-            journalforingstatusRepository.get(hendelse1.id) shouldBe Journalforingstatus(hendelse1.id, "12345", true)
-            journalforingstatusRepository.get(hendelse2.id) shouldBe Journalforingstatus(hendelse2.id, "12345", true)
+            journalforingstatusRepository.get(hendelse1.id) shouldBe Journalforingstatus(hendelse1.id, "12345")
+            journalforingstatusRepository.get(hendelse2.id) shouldBe Journalforingstatus(hendelse2.id, "12345")
 
             coVerify {
                 pdfgenClient.endringsvedtak(


### PR DESCRIPTION
https://trello.com/c/zuvo9AYv/1569-rydde-i-logikk-for-%C3%A5-identifisere-ikke-journalf%C3%B8rte-vedtak

Satte defaultverdien til false i databasen for eksisterende journalføringstatuser sånn at vi slipper at alle endringene som ikke skal journalføres fortsatt blir med i resultatet fra sql-en. 