### PR TITLE
tar med manuell oppfølging i vurdering av om det skal sendes brev

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -42,6 +42,9 @@ spec:
   kafka:
     pool: nav-dev
   accessPolicy:
+    inbound:
+      rules:
+        - application: amt-deltaker-bff
     outbound:
       rules:
         - application: amt-pdfgen

--- a/src/main/kotlin/no/nav/amt/distribusjon/Application.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/Application.kt
@@ -101,7 +101,7 @@ fun Application.module() {
     )
 
     val consumers = listOf(
-        HendelseConsumer(varselService, journalforingService, hendelseRepository, dokdistkanalClient),
+        HendelseConsumer(varselService, journalforingService, hendelseRepository, dokdistkanalClient, veilarboppfolgingClient),
         VarselHendelseConsumer(varselService),
     )
     consumers.forEach { it.run() }

--- a/src/main/kotlin/no/nav/amt/distribusjon/digitalbruker/DigitalBrukerService.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/digitalbruker/DigitalBrukerService.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.distribusjon.digitalbruker
 
+import no.nav.amt.distribusjon.distribusjonskanal.Distribusjonskanal
 import no.nav.amt.distribusjon.distribusjonskanal.DokdistkanalClient
 import no.nav.amt.distribusjon.distribusjonskanal.skalDistribueresDigitalt
 import no.nav.amt.distribusjon.veilarboppfolging.VeilarboppfolgingClient
@@ -8,6 +9,15 @@ class DigitalBrukerService(
     private val dokdistkanalClient: DokdistkanalClient,
     private val veilarboppfolgingClient: VeilarboppfolgingClient,
 ) {
+    companion object {
+        fun skalDistribueresDigitalt(distribusjonskanal: Distribusjonskanal, erUnderManuellOppfolging: Boolean): Boolean {
+            if (erUnderManuellOppfolging) {
+                return false
+            }
+            return distribusjonskanal.skalDistribueresDigitalt()
+        }
+    }
+
     suspend fun erDigital(personident: String): Boolean {
         val erUnderManuellOppfolging = veilarboppfolgingClient.erUnderManuellOppfolging(personident)
         if (erUnderManuellOppfolging) {

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseRepository.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/HendelseRepository.kt
@@ -20,6 +20,7 @@ class HendelseRepository {
         payload = objectMapper.readValue(row.string("payload")),
         opprettet = row.localDateTime("h.created_at"),
         distribusjonskanal = row.string("distribusjonskanal").let { Distribusjonskanal.valueOf(it) },
+        manuellOppfolging = row.boolean("manuelloppfolging"),
     )
 
     private fun rowmapperHendelseMedJournalforingstatus(row: Row) = HendelseMedJournalforingstatus(
@@ -30,6 +31,7 @@ class HendelseRepository {
             payload = objectMapper.readValue(row.string("payload")),
             opprettet = row.localDateTime("h.created_at"),
             distribusjonskanal = row.string("distribusjonskanal").let { Distribusjonskanal.valueOf(it) },
+            manuellOppfolging = row.boolean("manuelloppfolging"),
         ),
         journalforingstatus = Journalforingstatus(
             hendelseId = row.uuid("id"),
@@ -41,8 +43,8 @@ class HendelseRepository {
     fun insert(hendelse: Hendelse) = Database.query {
         val sql =
             """
-            insert into hendelse (id, deltaker_id, deltaker, ansvarlig, payload, distribusjonskanal)
-            values(:id, :deltaker_id, :deltaker, :ansvarlig, :payload, :distribusjonskanal)
+            insert into hendelse (id, deltaker_id, deltaker, ansvarlig, payload, distribusjonskanal, manuelloppfolging)
+            values(:id, :deltaker_id, :deltaker, :ansvarlig, :payload, :distribusjonskanal, :manuelloppfolging)
             on conflict (id) do nothing
             """.trimIndent()
 
@@ -53,6 +55,7 @@ class HendelseRepository {
             "ansvarlig" to toPGObject(hendelse.ansvarlig),
             "payload" to toPGObject(hendelse.payload),
             "distribusjonskanal" to hendelse.distribusjonskanal.name,
+            "manuelloppfolging" to hendelse.manuellOppfolging,
         )
 
         it.update(queryOf(sql, params))
@@ -67,6 +70,7 @@ class HendelseRepository {
                 h.payload as "payload",
                 h.created_at as "h.created_at",
                 h.distribusjonskanal as "distribusjonskanal",
+                h.manuelloppfolging as "manuelloppfolging",
                 js.journalpost_id as "journalpost_id",
                 js.bestillingsid as "bestillingsid"
             from hendelse h

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/Hendelse.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/Hendelse.kt
@@ -11,6 +11,7 @@ data class Hendelse(
     val ansvarlig: HendelseAnsvarlig,
     val payload: HendelseType,
     val distribusjonskanal: Distribusjonskanal,
+    val manuellOppfolging: Boolean,
 ) {
     fun erEndringsVedtakSomSkalJournalfores(): Boolean {
         return when (payload) {

--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/HendelseDto.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/HendelseDto.kt
@@ -11,12 +11,13 @@ data class HendelseDto(
     val ansvarlig: HendelseAnsvarlig,
     val payload: HendelseType,
 ) {
-    fun toModel(distribusjonskanal: Distribusjonskanal) = Hendelse(
+    fun toModel(distribusjonskanal: Distribusjonskanal, manuellOppfolging: Boolean) = Hendelse(
         id,
         opprettet,
         deltaker,
         ansvarlig,
         payload,
         distribusjonskanal,
+        manuellOppfolging,
     )
 }

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingService.kt
@@ -1,7 +1,7 @@
 package no.nav.amt.distribusjon.journalforing
 
+import no.nav.amt.distribusjon.digitalbruker.DigitalBrukerService
 import no.nav.amt.distribusjon.distribusjonskanal.Distribusjonskanal
-import no.nav.amt.distribusjon.distribusjonskanal.skalDistribueresDigitalt
 import no.nav.amt.distribusjon.hendelse.model.Hendelse
 import no.nav.amt.distribusjon.hendelse.model.HendelseAnsvarlig
 import no.nav.amt.distribusjon.hendelse.model.HendelseType
@@ -29,7 +29,7 @@ class JournalforingService(
 
     suspend fun handleHendelse(hendelse: Hendelse) {
         val journalforingstatus = journalforingstatusRepository.get(hendelse.id)
-        if (hendelseErBehandlet(journalforingstatus, hendelse.distribusjonskanal)) {
+        if (hendelseErBehandlet(journalforingstatus, hendelse.distribusjonskanal, hendelse.manuellOppfolging)) {
             log.info("Hendelse med id ${hendelse.id} for deltaker ${hendelse.deltaker.id} er allerede behandlet")
             return
         }
@@ -213,7 +213,7 @@ class JournalforingService(
             return
         }
         val nyesteHendelse = hendelser.maxBy { it.opprettet }
-        if (!nyesteHendelse.distribusjonskanal.skalDistribueresDigitalt()) {
+        if (!DigitalBrukerService.skalDistribueresDigitalt(nyesteHendelse.distribusjonskanal, nyesteHendelse.manuellOppfolging)) {
             val bestillingsId = dokdistfordelingClient.distribuerJournalpost(journalpostId)
             hendelser.forEach {
                 journalforingstatusRepository.upsert(
@@ -227,7 +227,14 @@ class JournalforingService(
         }
     }
 
-    private fun hendelseErBehandlet(journalforingstatus: Journalforingstatus?, distribusjonskanal: Distribusjonskanal): Boolean {
-        return journalforingstatus != null && journalforingstatus.erJournalfort() && journalforingstatus.erDistribuert(distribusjonskanal)
+    private fun hendelseErBehandlet(
+        journalforingstatus: Journalforingstatus?,
+        distribusjonskanal: Distribusjonskanal,
+        manuellOppfolging: Boolean,
+    ): Boolean {
+        return journalforingstatus != null && journalforingstatus.erJournalfort() && journalforingstatus.erDistribuert(
+            distribusjonskanal,
+            manuellOppfolging,
+        )
     }
 }

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/model/Journalforingstatus.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/model/Journalforingstatus.kt
@@ -1,7 +1,7 @@
 package no.nav.amt.distribusjon.journalforing.model
 
+import no.nav.amt.distribusjon.digitalbruker.DigitalBrukerService
 import no.nav.amt.distribusjon.distribusjonskanal.Distribusjonskanal
-import no.nav.amt.distribusjon.distribusjonskanal.skalDistribueresDigitalt
 import java.util.UUID
 
 data class Journalforingstatus(
@@ -13,8 +13,8 @@ data class Journalforingstatus(
         return journalpostId != null
     }
 
-    fun erDistribuert(distribusjonskanal: Distribusjonskanal): Boolean {
-        return if (distribusjonskanal.skalDistribueresDigitalt()) {
+    fun erDistribuert(distribusjonskanal: Distribusjonskanal, erUnderManuellOppfolging: Boolean): Boolean {
+        return if (DigitalBrukerService.skalDistribueresDigitalt(distribusjonskanal, erUnderManuellOppfolging)) {
             true
         } else {
             bestillingsId != null

--- a/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselService.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/varsel/VarselService.kt
@@ -2,7 +2,7 @@ package no.nav.amt.distribusjon.varsel
 
 import io.getunleash.Unleash
 import no.nav.amt.distribusjon.Environment
-import no.nav.amt.distribusjon.distribusjonskanal.skalDistribueresDigitalt
+import no.nav.amt.distribusjon.digitalbruker.DigitalBrukerService
 import no.nav.amt.distribusjon.hendelse.model.Hendelse
 import no.nav.amt.distribusjon.hendelse.model.HendelseDeltaker
 import no.nav.amt.distribusjon.hendelse.model.HendelseType
@@ -32,7 +32,7 @@ class VarselService(
             return
         }
 
-        if (!hendelse.distribusjonskanal.skalDistribueresDigitalt()) return
+        if (!DigitalBrukerService.skalDistribueresDigitalt(hendelse.distribusjonskanal, hendelse.manuellOppfolging)) return
 
         when (hendelse.payload) {
             is HendelseType.OpprettUtkast -> opprettPameldingsoppgave(hendelse)

--- a/src/main/resources/db/migration/V11__hendelse-manuelloppfolging.sql
+++ b/src/main/resources/db/migration/V11__hendelse-manuelloppfolging.sql
@@ -1,0 +1,3 @@
+alter table hendelse add column manuelloppfolging boolean not null default false;
+
+alter table hendelse alter column manuelloppfolging drop default;

--- a/src/test/kotlin/no/nav/amt/distribusjon/TestApp.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/TestApp.kt
@@ -96,7 +96,15 @@ class TestApp {
         val consumerId = UUID.randomUUID().toString()
         val kafkaConfig = LocalKafkaConfig(SingletonKafkaProvider.getHost())
         val consumers = listOf(
-            HendelseConsumer(varselService, journalforingService, hendelseRepository, dokdistkanalClient, consumerId, kafkaConfig),
+            HendelseConsumer(
+                varselService,
+                journalforingService,
+                hendelseRepository,
+                dokdistkanalClient,
+                veilarboppfolgingClient,
+                consumerId,
+                kafkaConfig,
+            ),
             VarselHendelseConsumer(varselService, consumerId, kafkaConfig),
         )
 

--- a/src/test/kotlin/no/nav/amt/distribusjon/hendelse/consumer/VarselTest.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/hendelse/consumer/VarselTest.kt
@@ -39,7 +39,7 @@ class VarselTest {
             val varsel = app.varselRepository.getSisteVarsel(hendelse.deltaker.id, Varsel.Type.OPPGAVE).getOrThrow()
 
             varsel.aktivTil shouldBe null
-            varsel.tekst shouldBe oppgaveTekst(hendelse.toModel(Distribusjonskanal.DITT_NAV))
+            varsel.tekst shouldBe oppgaveTekst(hendelse.toModel(Distribusjonskanal.DITT_NAV, false))
             varsel.erSendt shouldBe true
             varsel.aktivFra shouldBeCloseTo nowUTC()
             varsel.deltakerId shouldBe hendelse.deltaker.id
@@ -74,6 +74,20 @@ class VarselTest {
     @Test
     fun `navGodkjennUtkast - innbyggers distribusjonskanal er ikke digital - oppretter ikke varsel`() = integrationTest { app, _ ->
         val hendelse = Hendelsesdata.hendelse(HendelseTypeData.navGodkjennUtkast(), distribusjonskanal = Distribusjonskanal.PRINT)
+
+        app.varselService.handleHendelse(hendelse)
+
+        val varsel = app.varselRepository.getSisteVarsel(hendelse.deltaker.id, Varsel.Type.BESKJED).getOrNull()
+        varsel shouldBe null
+    }
+
+    @Test
+    fun `navGodkjennUtkast - innbyggers er under manuell oppfolging - oppretter ikke varsel`() = integrationTest { app, _ ->
+        val hendelse = Hendelsesdata.hendelse(
+            HendelseTypeData.navGodkjennUtkast(),
+            distribusjonskanal = Distribusjonskanal.SDP,
+            manuellOppfolging = true,
+        )
 
         app.varselService.handleHendelse(hendelse)
 
@@ -179,7 +193,7 @@ class VarselTest {
         val varsel = app.varselRepository.getSisteVarsel(hendelse.deltaker.id, Varsel.Type.BESKJED).getOrThrow()
 
         varsel.aktivTil!! shouldBeCloseTo nowUTC().plus(VarselService.beskjedAktivLengde)
-        varsel.tekst shouldBe beskjedTekst(hendelse.toModel(Distribusjonskanal.DITT_NAV))
+        varsel.tekst shouldBe beskjedTekst(hendelse.toModel(Distribusjonskanal.DITT_NAV, false))
         varsel.aktivFra shouldBeCloseTo aktivFra
         varsel.deltakerId shouldBe hendelse.deltaker.id
         varsel.personident shouldBe hendelse.deltaker.personident
@@ -228,4 +242,4 @@ fun assertProducedBeskjed(id: UUID) = assertProduced(Environment.MINSIDE_VARSEL_
     }
 }
 
-fun HendelseDto.skalVarslesEksternt() = this.toModel(Distribusjonskanal.DITT_NAV).skalVarslesEksternt()
+fun HendelseDto.skalVarslesEksternt() = this.toModel(Distribusjonskanal.DITT_NAV, false).skalVarslesEksternt()

--- a/src/test/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingServiceTest.kt
@@ -68,6 +68,23 @@ class JournalforingServiceTest {
     }
 
     @Test
+    fun `handleHendelse - NavGodkjennUtkast, manuell oppfolging - sender brev`() = integrationTest { app, _ ->
+        val hendelse = Hendelsesdata.hendelse(
+            HendelseTypeData.navGodkjennUtkast(),
+            distribusjonskanal = Distribusjonskanal.SDP,
+            manuellOppfolging = true,
+        )
+
+        app.hendelseRepository.insert(hendelse)
+
+        app.journalforingService.handleHendelse(hendelse)
+
+        val status = app.journalforingstatusRepository.get(hendelse.id)
+        status!!.journalpostId shouldNotBe null
+        status.bestillingsId shouldNotBe null
+    }
+
+    @Test
     fun `handleHendelse - AvsluttDeltakelse, er allerede journalfort, skal ikke sende brev - ignorerer hendelse`() = integrationTest {
             app,
             _,
@@ -102,7 +119,7 @@ class JournalforingServiceTest {
 
         assertThrows(IllegalArgumentException::class.java) {
             runBlocking {
-                app.journalforingService.handleHendelse(hendelse.toModel(Distribusjonskanal.DITT_NAV))
+                app.journalforingService.handleHendelse(hendelse.toModel(Distribusjonskanal.DITT_NAV, false))
             }
         }
     }

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/TestRepository.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/TestRepository.kt
@@ -25,8 +25,8 @@ object TestRepository {
     fun insert(hendelse: Hendelse) = Database.query {
         val sql =
             """
-            insert into hendelse (id, deltaker_id, deltaker, ansvarlig, payload, distribusjonskanal, created_at)
-            values(:id, :deltaker_id, :deltaker, :ansvarlig, :payload, :distribusjonskanal, :created_at)
+            insert into hendelse (id, deltaker_id, deltaker, ansvarlig, payload, distribusjonskanal, manuelloppfolging, created_at)
+            values(:id, :deltaker_id, :deltaker, :ansvarlig, :payload, :distribusjonskanal, :manuelloppfolging, :created_at)
             on conflict (id) do nothing
             """.trimIndent()
 
@@ -38,6 +38,7 @@ object TestRepository {
             "payload" to toPGObject(hendelse.payload),
             "created_at" to hendelse.opprettet,
             "distribusjonskanal" to hendelse.distribusjonskanal.name,
+            "manuelloppfolging" to hendelse.manuellOppfolging,
         )
 
         it.update(queryOf(sql, params))

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Hendelsesdata.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Hendelsesdata.kt
@@ -34,13 +34,14 @@ object Hendelsesdata {
         ansvarlig: HendelseAnsvarlig = ansvarligNavVeileder(),
         opprettet: LocalDateTime = LocalDateTime.now(),
         distribusjonskanal: Distribusjonskanal = Distribusjonskanal.DITT_NAV,
+        manuellOppfolging: Boolean = false,
     ) = hendelseDto(
         payload,
         id,
         deltaker,
         ansvarlig,
         opprettet,
-    ).toModel(distribusjonskanal)
+    ).toModel(distribusjonskanal, manuellOppfolging)
 
     fun ansvarligNavVeileder(
         id: UUID = UUID.randomUUID(),


### PR DESCRIPTION
https://trello.com/c/4dLDjNQu/1593-endre-logikk-for-h%C3%A5ndtering-av-hendelser-slik-at-vi-ogs%C3%A5-sjekker-om-bruker-er-under-manuell-oppf%C3%B8lging

Jeg valgte å lage en statisk metode i DigitalBrukerService slik at logikken for om det skal sendes brev eller ikke iallefall er samlet i samme klasse. Siden vi lagrer distribusjonskanal sammen med hendelsen så tenkte jeg det ga mening å gjøre det samme med manuell oppfølging også. Det er mange måter å gjøre dette her på, så jeg er åpen for innspill til andre og bedre måter :)

Glemte forøvrig å gi amt-deltaker-bff tilgang til apiet jeg lagde i forrige pr, så gjorde det nå :)