### PR TITLE
defaulter til tom liste hvis innhold er null

### DIFF
--- a/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/HendelseType.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/hendelse/model/HendelseType.kt
@@ -114,7 +114,7 @@ data class Utkast(
     val dagerPerUke: Float?,
     val deltakelsesprosent: Float?,
     val bakgrunnsinformasjon: String?,
-    val innhold: List<Innhold>,
+    val innhold: List<Innhold> = emptyList(),
 )
 
 data class Aarsak(


### PR DESCRIPTION
Arenadeltakere som ikke har innhold og som reaktiveres skaper krøll. 