### PR TITLE
oppdaterer amt-lib for å få shutdownhook for kafkaconsumer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,6 @@ val jacksonVersion = "2.18.2"
 val logstashEncoderVersion = "8.0"
 val commonVersion = "3.2024.10.25_13.44-9db48a0dbe67"
 val kafkaClientsVersion = "3.9.0"
-val testcontainersVersion = "1.20.1"
 val kotestVersion = "5.9.1"
 val flywayVersion = "11.1.0"
 val hikariVersion = "6.2.1"
@@ -36,7 +35,7 @@ val postgresVersion = "42.7.4"
 val caffeineVersion = "3.1.8"
 val unleashVersion = "9.2.6"
 val nimbusVersion = "9.47"
-val amtLibVersion = "1.2024.11.21_05.47-140eeb3c0bfa"
+val amtLibVersion = "1.2024.12.16_11.44-f6e1d4a5b217"
 
 dependencies {
     implementation("io.ktor:ktor-server-content-negotiation-jvm")


### PR DESCRIPTION
https://trello.com/c/AePqmJ6G/2047-stoppe-kafkaconsumer-n%C3%A5r-appen-er-p%C3%A5-vei-til-%C3%A5-stoppe