### PR TITLE
Bumper amt lib.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ val postgresVersion = "42.7.5"
 val caffeineVersion = "3.2.0"
 val unleashVersion = "10.2.2"
 val nimbusVersion = "10.0.2"
-val amtLibVersion = "1.2025.02.12_12.23-94b6e1374ff8"
+val amtLibVersion = "1.2025.04.02_06.22-91ff72b904a0"
 
 dependencies {
     implementation("io.ktor:ktor-server-content-negotiation-jvm")

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Hendelsesdata.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Hendelsesdata.kt
@@ -75,7 +75,10 @@ object Hendelsesdata {
         navn: String = "Deltakerlistenavn",
         arrangor: HendelseDeltaker.Deltakerliste.Arrangor = arrangor(),
         tiltak: HendelseDeltaker.Deltakerliste.Tiltak = tiltak(),
-    ) = HendelseDeltaker.Deltakerliste(id, navn, arrangor, tiltak)
+        startdato: LocalDate = LocalDate.now(),
+        sluttdato: LocalDate? = LocalDate.now().plusDays(1),
+        oppstartstype: HendelseDeltaker.Deltakerliste.Oppstartstype = HendelseDeltaker.Deltakerliste.Oppstartstype.LOPENDE,
+    ) = HendelseDeltaker.Deltakerliste(id, navn, arrangor, tiltak, startdato, sluttdato, oppstartstype)
 
     fun arrangor(
         id: UUID = UUID.randomUUID(),


### PR DESCRIPTION
 Bumpingen må skje før den funskjonelle endringen i den andre pren min slik at vi lagrer ny versjon av deltakere i dev og prod og får bearbeidet hendelser som skal itereres over i endringsvedtakjobben