### PR TITLE
Legger til felter som skal være med i pdf med støtte for at det er forskjell på tittel og navnet i ingressen

### DIFF
--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/JournalforingService.kt
@@ -132,6 +132,7 @@ class JournalforingService(
                     deltaker = hendelse.deltaker,
                     navBruker = navBruker,
                     veileder = hendelse.ansvarlig.hentVeileder(),
+                    opprettetDato = hendelse.opprettet.toLocalDate(),
                 ),
             )
         }

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/EndringsvedtakPdfDto.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/EndringsvedtakPdfDto.kt
@@ -10,6 +10,9 @@ data class EndringsvedtakPdfDto(
     val avsender: AvsenderDto,
     val vedtaksdato: LocalDate,
     val forsteVedtakFattet: LocalDate,
+    val sidetittel: String,
+    val ingressnavn: String,
+    val opprettetDato: LocalDate,
 ) {
     data class DeltakerDto(
         val fornavn: String,

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/HovedvedtakPdfDto.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/HovedvedtakPdfDto.kt
@@ -9,6 +9,9 @@ data class HovedvedtakPdfDto(
     val avsender: AvsenderDto,
     val vedtaksdato: LocalDate,
     val begrunnelseFraNav: String? = null,
+    val sidetittel: String,
+    val ingressnavn: String,
+    val opprettetDato: LocalDate,
 ) {
     data class DeltakerDto(
         val fornavn: String,

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/InnsokingsbrevPdfDto.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/InnsokingsbrevPdfDto.kt
@@ -1,11 +1,15 @@
 package no.nav.amt.distribusjon.journalforing.pdf
 
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakstype
+import java.time.LocalDate
 
 data class InnsokingsbrevPdfDto(
     val deltaker: DeltakerDto,
     val deltakerliste: DeltakerlisteDto,
     val avsender: AvsenderDto,
+    val sidetittel: String,
+    val ingressnavn: String,
+    val opprettetDato: LocalDate,
 ) {
     data class DeltakerDto(
         val fornavn: String,

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/PdfUtils.kt
@@ -47,7 +47,7 @@ fun lagHovedvedtakPdfDto(
         adresseDelesMedArrangor = adresseDelesMedArrangor(deltaker, navBruker),
     ),
     deltakerliste = HovedvedtakPdfDto.DeltakerlisteDto(
-        navn = deltaker.deltakerliste.visningsnavn(),
+        navn = deltaker.deltakerliste.tittelVisningsnavn(),
         tiltakskode = deltaker.deltakerliste.tiltak.tiltakskode,
         ledetekst = deltaker.deltakerliste.tiltak.ledetekst ?: "",
         arrangor = HovedvedtakPdfDto.ArrangorDto(
@@ -61,6 +61,9 @@ fun lagHovedvedtakPdfDto(
     ),
     vedtaksdato = vedtaksdato,
     begrunnelseFraNav = begrunnelseFraNav,
+    sidetittel = deltaker.deltakerliste.tittelVisningsnavn(),
+    ingressnavn = deltaker.deltakerliste.ingressVisningsnavn(),
+    opprettetDato = LocalDate.now(),
 )
 
 fun lagInnsokingsbrevPdfDto(
@@ -75,7 +78,7 @@ fun lagInnsokingsbrevPdfDto(
         personident = deltaker.personident,
     ),
     deltakerliste = InnsokingsbrevPdfDto.DeltakerlisteDto(
-        navn = deltaker.deltakerliste.visningsnavn(),
+        navn = deltaker.deltakerliste.tittelVisningsnavn(),
         tiltakskode = deltaker.deltakerliste.tiltak.tiltakskode,
         arrangor = ArrangorDto(
             navn = deltaker.deltakerliste.arrangor.visningsnavn(),
@@ -87,6 +90,9 @@ fun lagInnsokingsbrevPdfDto(
         navn = veileder.navn,
         enhet = navBruker.navEnhet?.navn ?: "NAV",
     ),
+    sidetittel = deltaker.deltakerliste.tittelVisningsnavn(),
+    ingressnavn = deltaker.deltakerliste.ingressVisningsnavn(),
+    opprettetDato = LocalDate.now(),
 )
 
 fun lagEndringsvedtakPdfDto(
@@ -106,7 +112,7 @@ fun lagEndringsvedtakPdfDto(
             personident = deltaker.personident,
         ),
         deltakerliste = EndringsvedtakPdfDto.DeltakerlisteDto(
-            navn = deltaker.deltakerliste.visningsnavn(),
+            navn = deltaker.deltakerliste.tittelVisningsnavn(),
             ledetekst = deltaker.deltakerliste.tiltak.ledetekst ?: "",
             arrangor = EndringsvedtakPdfDto.ArrangorDto(
                 navn = deltaker.deltakerliste.arrangor.visningsnavn(),
@@ -121,6 +127,9 @@ fun lagEndringsvedtakPdfDto(
         vedtaksdato = vedtaksdato,
         forsteVedtakFattet = deltaker.forsteVedtakFattet
             ?: throw IllegalStateException("Kan ikke journalføre endringsvedtak hvis opprinnelig vedtak ikke er fattet"),
+        sidetittel = deltaker.deltakerliste.tittelVisningsnavn(),
+        ingressnavn = deltaker.deltakerliste.ingressVisningsnavn(),
+        opprettetDato = LocalDate.now(),
     )
 }
 
@@ -152,11 +161,20 @@ fun HendelseDeltaker.Deltakerliste.forskriftskapittel() = when (this.tiltak.tilt
     Tiltakstype.Tiltakskode.VARIG_TILRETTELAGT_ARBEID_SKJERMET -> 14
 }
 
-fun HendelseDeltaker.Deltakerliste.visningsnavn() = when (this.tiltak.tiltakskode) {
+fun HendelseDeltaker.Deltakerliste.tittelVisningsnavn() = when (this.tiltak.tiltakskode) {
     Tiltakstype.Tiltakskode.VARIG_TILRETTELAGT_ARBEID_SKJERMET -> "Varig tilrettelagt arbeid hos ${this.arrangor.visningsnavn()}"
     Tiltakstype.Tiltakskode.JOBBKLUBB -> "Jobbsøkerkurs hos ${arrangor.visningsnavn()}"
-    Tiltakstype.Tiltakskode.GRUPPE_FAG_OG_YRKESOPPLAERING -> this.navn
+    Tiltakstype.Tiltakskode.GRUPPE_ARBEIDSMARKEDSOPPLAERING -> "Arbeidsmarkedsopplæring hos ${this.arrangor.visningsnavn()}"
+    Tiltakstype.Tiltakskode.GRUPPE_FAG_OG_YRKESOPPLAERING -> "Fag- og yrkesopplæring hos ${this.arrangor.visningsnavn()}"
     else -> "${this.tiltak.navn} hos ${arrangor.visningsnavn()}"
+}
+
+fun HendelseDeltaker.Deltakerliste.ingressVisningsnavn() = when (this.tiltak.tiltakskode) {
+    Tiltakstype.Tiltakskode.JOBBKLUBB -> "Jobbsøkerkurs hos ${arrangor.visningsnavn()}"
+    Tiltakstype.Tiltakskode.GRUPPE_ARBEIDSMARKEDSOPPLAERING,
+    Tiltakstype.Tiltakskode.GRUPPE_FAG_OG_YRKESOPPLAERING,
+    -> "${this.navn} hos ${arrangor.visningsnavn()}"
+    else -> tittelVisningsnavn()
 }
 
 fun HendelseDeltaker.Deltakerliste.Arrangor.visningsnavn(): String = with(overordnetArrangor) {

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/PdfUtils.kt
@@ -63,13 +63,14 @@ fun lagHovedvedtakPdfDto(
     begrunnelseFraNav = begrunnelseFraNav,
     sidetittel = deltaker.deltakerliste.tittelVisningsnavn(),
     ingressnavn = deltaker.deltakerliste.ingressVisningsnavn(),
-    opprettetDato = LocalDate.now(),
+    opprettetDato = vedtaksdato,
 )
 
 fun lagInnsokingsbrevPdfDto(
     deltaker: HendelseDeltaker,
     navBruker: NavBruker,
     veileder: HendelseAnsvarlig.NavVeileder,
+    opprettetDato: LocalDate,
 ) = InnsokingsbrevPdfDto(
     deltaker = InnsokingsbrevPdfDto.DeltakerDto(
         fornavn = navBruker.fornavn,
@@ -92,7 +93,7 @@ fun lagInnsokingsbrevPdfDto(
     ),
     sidetittel = deltaker.deltakerliste.tittelVisningsnavn(),
     ingressnavn = deltaker.deltakerliste.ingressVisningsnavn(),
-    opprettetDato = LocalDate.now(),
+    opprettetDato = opprettetDato,
 )
 
 fun lagEndringsvedtakPdfDto(
@@ -100,7 +101,7 @@ fun lagEndringsvedtakPdfDto(
     navBruker: NavBruker,
     ansvarlig: HendelseAnsvarlig,
     hendelser: List<Hendelse>,
-    vedtaksdato: LocalDate,
+    opprettetDato: LocalDate,
 ): EndringsvedtakPdfDto {
     val endringer = fjernEldreHendelserAvSammeType(hendelser).map { it.payload }
 
@@ -124,12 +125,12 @@ fun lagEndringsvedtakPdfDto(
             navn = ansvarlig.getAvsendernavn(),
             enhet = navBruker.navEnhet?.navn ?: "NAV",
         ),
-        vedtaksdato = vedtaksdato,
+        vedtaksdato = opprettetDato,
         forsteVedtakFattet = deltaker.forsteVedtakFattet
             ?: throw IllegalStateException("Kan ikke journalføre endringsvedtak hvis opprinnelig vedtak ikke er fattet"),
         sidetittel = deltaker.deltakerliste.tittelVisningsnavn(),
         ingressnavn = deltaker.deltakerliste.ingressVisningsnavn(),
-        opprettetDato = LocalDate.now(),
+        opprettetDato = opprettetDato,
     )
 }
 


### PR DESCRIPTION
* Legger til støtte for at navnet på gjennomføringen skal være forskjellig i ingress og tittel
* Legger også inn dato som skal vises på alle brev på høyre side som skal erstatte "vedtaksdato" som egentlig inneholdt hendelse opprettet dato.
* Justerer tekstene for å passe med skisser
https://trello.com/c/0m8P1j5M/2207-lage-brev-for-s%C3%B8kt-inn