### PR TITLE
Fikser feil som gjør at endringsvedtak feiler hvis ikke hovedvedtak er fattet

### DIFF
--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/EndringsvedtakPdfDto.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/EndringsvedtakPdfDto.kt
@@ -9,7 +9,7 @@ data class EndringsvedtakPdfDto(
     val endringer: List<EndringDto>,
     val avsender: AvsenderDto,
     val vedtaksdato: LocalDate,
-    val forsteVedtakFattet: LocalDate,
+    val forsteVedtakFattet: LocalDate?,
     val sidetittel: String,
     val ingressnavn: String,
     val opprettetDato: LocalDate,

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/pdf/PdfUtils.kt
@@ -155,8 +155,7 @@ fun lagEndringsvedtakPdfDto(
             enhet = navBruker.navEnhet?.navn ?: "NAV",
         ),
         vedtaksdato = opprettetDato,
-        forsteVedtakFattet = deltaker.forsteVedtakFattet
-            ?: throw IllegalStateException("Kan ikke journalføre endringsvedtak hvis opprinnelig vedtak ikke er fattet"),
+        forsteVedtakFattet = deltaker.forsteVedtakFattet,
         sidetittel = deltaker.deltakerliste.tittelVisningsnavn(),
         ingressnavn = deltaker.deltakerliste.ingressVisningsnavn(),
         opprettetDato = opprettetDato,


### PR DESCRIPTION
Er veldig usikker siden denne sjekken er så mange steder så må sjekke litt

- Hva skjer og skal skje når man endrer på arenadeltaker som ikke har hovedvedtak?
- Hvilke flyter fører til at man ikke har hovedvedtak men det kan trigges endringer som kan gi endringsvedtak?