### PR TITLE
Sett journalpost sin tema til å være en config

### DIFF
--- a/src/main/kotlin/no/nav/amt/distribusjon/Environment.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/Environment.kt
@@ -46,6 +46,7 @@ data class Environment(
         const val DOKDISTKANAL_SCOPE_KEY = "DOKDISTKANAL_SCOPE"
         const val DOKDISTFORDELING_URL_KEY = "DOKDISTFORDELING_URL"
         const val SAF_SCOPE_KEY = "SAF_SCOPE"
+        const val SAF_TEMA = "OPP"
 
         const val ELECTOR_PATH = "ELECTOR_PATH"
 

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/dokarkiv/DokarkivClient.kt
@@ -75,35 +75,33 @@ class DokarkivClient(
         journalforendeEnhet: String,
         tiltakstype: HendelseDeltaker.Deltakerliste.Tiltak,
         journalpostNavn: String,
-    ): OpprettJournalpostRequest {
-        return OpprettJournalpostRequest(
-            avsenderMottaker = AvsenderMottaker(
-                id = fnr,
-            ),
-            bruker = Bruker(
-                id = fnr,
-            ),
-            dokumenter = listOf(
-                Dokument(
-                    brevkode = getBrevkode(tiltakstype),
-                    dokumentvarianter = listOf(
-                        DokumentVariant(
-                            fysiskDokument = pdf,
-                        ),
+    ): OpprettJournalpostRequest = OpprettJournalpostRequest(
+        avsenderMottaker = AvsenderMottaker(
+            id = fnr,
+        ),
+        bruker = Bruker(
+            id = fnr,
+        ),
+        dokumenter = listOf(
+            Dokument(
+                brevkode = getBrevkode(tiltakstype),
+                dokumentvarianter = listOf(
+                    DokumentVariant(
+                        fysiskDokument = pdf,
                     ),
-                    tittel = journalpostNavn,
                 ),
+                tittel = journalpostNavn,
             ),
-            journalfoerendeEnhet = journalforendeEnhet,
-            sak = Sak(
-                fagsakId = sak.sakId.toString(),
-                fagsaksystem = sak.fagsaksystem,
-            ),
-            tema = sak.tema,
-            tittel = journalpostNavn,
-            eksternReferanseId = hendelseId.toString(),
-        )
-    }
+        ),
+        journalfoerendeEnhet = journalforendeEnhet,
+        sak = Sak(
+            fagsakId = sak.sakId.toString(),
+            fagsaksystem = sak.fagsaksystem,
+        ),
+        tema = Environment.SAF_TEMA,
+        tittel = journalpostNavn,
+        eksternReferanseId = hendelseId.toString(),
+    )
 
     private fun getBrevkode(tiltakstype: HendelseDeltaker.Deltakerliste.Tiltak): String = "tiltak-vedtak-${tiltakstype.type.name}"
 }

--- a/src/main/kotlin/no/nav/amt/distribusjon/veilarboppfolging/VeilarboppfolgingClient.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/veilarboppfolging/VeilarboppfolgingClient.kt
@@ -25,7 +25,8 @@ class VeilarboppfolgingClient(
     private val url = environment.veilarboppfolgingUrl
     private val consumerId: String = "amt-distribusjon"
 
-    private val manuellOppfolgingCache = Caffeine.newBuilder()
+    private val manuellOppfolgingCache = Caffeine
+        .newBuilder()
         .expireAfterWrite(Duration.ofMinutes(60))
         .build<String, Boolean>()
 
@@ -66,7 +67,6 @@ data class Sak(
     val oppfolgingsperiodeId: UUID,
     val sakId: Long,
     val fagsaksystem: String,
-    val tema: String,
 )
 
 data class ManuellStatusRequest(

--- a/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Journalforingdata.kt
+++ b/src/test/kotlin/no/nav/amt/distribusjon/utils/data/Journalforingdata.kt
@@ -8,6 +8,5 @@ object Journalforingdata {
         oppfolgingsperiodeId: UUID = UUID.randomUUID(),
         sakId: Long = (1000L..99999L).random(),
         fagsaksystem: String = "ARBEIDSOPPFOLGING",
-        tema: String = "OPP",
-    ) = Sak(oppfolgingsperiodeId, sakId, fagsaksystem, tema)
+    ) = Sak(oppfolgingsperiodeId, sakId, fagsaksystem)
 }


### PR DESCRIPTION
Det er skummelt å utlede tema fra en client, for vi må faktisk ha tilgang til det temaet vi sender, når vi skal sende brev.