### PR TITLE
Bump dependencies - 20250707091654

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ val hikariVersion = "6.3.0"
 val kotliqueryVersion = "1.9.1"
 val postgresVersion = "42.7.7"
 val caffeineVersion = "3.2.1"
-val unleashVersion = "11.0.1"
+val unleashVersion = "11.0.2"
 val nimbusVersion = "10.3.1"
 val amtLibVersion = "1.2025.07.03_09.15-e63d3f075ead"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     val kotlinVersion = "2.2.0"
 
     kotlin("jvm") version kotlinVersion
-    id("io.ktor.plugin") version "3.2.0"
+    id("io.ktor.plugin") version "3.2.1"
     id("org.jetbrains.kotlin.plugin.serialization") version kotlinVersion
     id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
     id("com.gradleup.shadow") version "8.3.8"


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250707091654 branch:

## Successfully Rebased PRs
- [Bump io.getunleash:unleash-client-java from 11.0.1 to 11.0.2](https://github.com/navikt/amt-distribusjon/pull/330)
- [Bump io.ktor.plugin from 3.2.0 to 3.2.1](https://github.com/navikt/amt-distribusjon/pull/329)


