### PR TITLE
Bump dependencies - 20250722124914

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ val kotliqueryVersion = "1.9.1"
 val postgresVersion = "42.7.7"
 val caffeineVersion = "3.2.2"
 val unleashVersion = "11.0.2"
-val nimbusVersion = "10.3.1"
+val nimbusVersion = "10.4"
 val amtLibVersion = "1.2025.07.21_09.55-93558d2bbc68"
 
 dependencies {


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250722124914 branch:

## Successfully Rebased PRs
- [Bump com.nimbusds:nimbus-jose-jwt from 10.3.1 to 10.4](https://github.com/navikt/amt-distribusjon/pull/350)
- [Bump amtLibVersion from 1.2025.07.03_09.15-e63d3f075ead to 1.2025.07.21_09.55-93558d2bbc68](https://github.com/navikt/amt-distribusjon/pull/349)
- [Bump no.nav.common:log from 3.2024.10.25_13.44-9db48a0dbe67 to 3.2025.06.23_14.50-3af3985d8555](https://github.com/navikt/amt-distribusjon/pull/348)
- [Bump com.zaxxer:HikariCP from 6.3.0 to 6.3.1](https://github.com/navikt/amt-distribusjon/pull/346)


