### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -105,5 +105,5 @@ spec:
       value: api://dev-fss.teamdokumenthandtering.dokdistkanal/.default
     - name: DOKDISTFORDELING_URL
       value: https://dokdistfordeling.dev-fss-pub.nais.io
-    - name: SAF_SCOPE
-      value: api://dev-fss.teamdokumenthandtering.saf/.default
+    - name: DOKDISTFORDELING_SCOPE
+      value: api://dev-fss.teamdokumenthandtering.dokdistfordeling/.default

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -111,5 +111,5 @@ spec:
       value: api://prod-fss.teamdokumenthandtering.dokdistkanal/.default
     - name: DOKDISTFORDELING_URL
       value: https://dokdistfordeling.prod-fss-pub.nais.io
-    - name: SAF_SCOPE
-      value: api://prod-fss.teamdokumenthandtering.saf/.default
+    - name: DOKDISTFORDELING_SCOPE
+      value: api://prod-fss.teamdokumenthandtering.dokdistfordeling/.default

--- a/src/main/kotlin/no/nav/amt/distribusjon/Environment.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/Environment.kt
@@ -21,7 +21,7 @@ data class Environment(
     val dokdistkanalUrl: String = getEnvVar(DOKDISTKANAL_URL_KEY),
     val dokdistkanalScope: String = getEnvVar(DOKDISTKANAL_SCOPE_KEY),
     val dokdistfordelingUrl: String = getEnvVar(DOKDISTFORDELING_URL_KEY),
-    val safScope: String = getEnvVar(SAF_SCOPE_KEY),
+    val dokdistfordelingScope: String = getEnvVar(DOKDISTFORDELING_SCOPE_KEY),
     val leaderElectorUrl: String = getEnvVar(LEADER_ELECTOR_URL),
 ) {
     companion object {
@@ -45,7 +45,7 @@ data class Environment(
         const val DOKDISTKANAL_URL_KEY = "DOKDISTKANAL_URL"
         const val DOKDISTKANAL_SCOPE_KEY = "DOKDISTKANAL_SCOPE"
         const val DOKDISTFORDELING_URL_KEY = "DOKDISTFORDELING_URL"
-        const val SAF_SCOPE_KEY = "SAF_SCOPE"
+        const val DOKDISTFORDELING_SCOPE_KEY = "DOKDISTFORDELING_SCOPE"
         const val SAF_TEMA = "OPP"
 
         const val LEADER_ELECTOR_URL = "ELECTOR_GET_URL"

--- a/src/main/kotlin/no/nav/amt/distribusjon/journalforing/dokdistfordeling/DokdistfordelingClient.kt
+++ b/src/main/kotlin/no/nav/amt/distribusjon/journalforing/dokdistfordeling/DokdistfordelingClient.kt
@@ -22,7 +22,7 @@ class DokdistfordelingClient(
     private val azureAdTokenClient: AzureAdTokenClient,
     environment: Environment,
 ) {
-    private val scope = environment.safScope
+    private val scope = environment.dokdistfordelingScope
     private val url = environment.dokdistfordelingUrl
     private val navCallId = Environment.appName
     private val log = LoggerFactory.getLogger(javaClass)


### PR DESCRIPTION
* Fra saf-scope til dokdistfordeling-scope for dokdistfordeling integrasjonen
* Endret `SAF_SCOPE_KEY` til `DOKDISTFORDELING_SCOPE_KEY` og tilsvarende for ENV
* Endret variabelnavn fra saf til dokdistfordeling

> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.

Har dobbeltsjekket dokdistfordeling config og `prod-gcp:amt:amt-distribusjon` ligger inne i dokdistfordeling sin preauthorized liste. Så dere skal ikke merke noe. 🙇